### PR TITLE
Logging Framework

### DIFF
--- a/logging/Logging.test.ts
+++ b/logging/Logging.test.ts
@@ -1,0 +1,100 @@
+import { repeatElements } from "../lib/Array"
+import { fakeTimers } from "../test-helpers/FakeTimers"
+import {
+  LOG_LEVELS,
+  addLogHandler,
+  logger,
+  defaultFormatLogMessage,
+  resetLogHandlers
+} from "./Logging"
+
+describe("Logging tests", () => {
+  describe("DefaultLogFormatter tests", () => {
+    fakeTimers()
+
+    beforeEach(() => jest.setSystemTime(new Date("2024-03-19T04:41:44.385Z")))
+
+    test("formatting for each log level with metadata", () => {
+      expect(
+        defaultFormatLogMessage("test.label", "debug", "Hello world", {
+          key: "value"
+        })
+      ).toEqual(
+        '2024-03-19T04:41:44.385Z [test.label] (DEBUG 🟢) Hello world {"key":"value"}\n'
+      )
+      expect(
+        defaultFormatLogMessage("test.label", "info", "Hello world", {
+          key: "value"
+        })
+      ).toEqual(
+        '2024-03-19T04:41:44.385Z [test.label] (INFO 🔵) Hello world {"key":"value"}\n'
+      )
+      expect(
+        defaultFormatLogMessage("test.label", "trace", "Hello world", {
+          key: "value"
+        })
+      ).toEqual(
+        '2024-03-19T04:41:44.385Z [test.label] (TRACE ⚪️) Hello world {"key":"value"}\n'
+      )
+      expect(
+        defaultFormatLogMessage("test.label", "warn", "Hello world", {
+          key: "value"
+        })
+      ).toEqual(
+        '2024-03-19T04:41:44.385Z [test.label] (WARN 🟡) Hello world {"key":"value"}\n'
+      )
+      expect(
+        defaultFormatLogMessage("test.label", "error", "Hello world", {
+          key: "value"
+        })
+      ).toEqual(
+        '2024-03-19T04:41:44.385Z [test.label] (ERROR 🔴) Hello world {"key":"value"}\n'
+      )
+    })
+
+    test("formatting without metadata", () => {
+      expect(
+        defaultFormatLogMessage("test.label", "error", "Hello world")
+      ).toEqual(
+        "2024-03-19T04:41:44.385Z [test.label] (ERROR 🔴) Hello world\n"
+      )
+    })
+  })
+
+  describe("CreateLogFunction tests", () => {
+    const log = logger("test.log.function")
+
+    const testLogHandlers = repeatElements(5, () => jest.fn())
+
+    it("should log to all log handlers", () => {
+      testLogHandlers.forEach(addLogHandler)
+      LOG_LEVELS.forEach((level) => {
+        log[level]("Test", { key: "value" })
+        testLogHandlers.forEach((handler) => {
+          expect(handler).toHaveBeenCalledWith(
+            "test.log.function",
+            level,
+            "Test",
+            {
+              key: "value"
+            }
+          )
+          expect(handler).toHaveBeenCalledTimes(1)
+          handler.mockReset()
+        })
+      })
+    })
+
+    it("should not log to any handler after resetting", () => {
+      testLogHandlers.forEach(addLogHandler)
+      resetLogHandlers()
+      LOG_LEVELS.forEach((level) => {
+        log[level]("Test", { key: "value" })
+        testLogHandlers.forEach((handler) => {
+          expect(handler).not.toHaveBeenCalled()
+          handler.mockReset()
+        })
+      })
+    })
+  })
+})

--- a/logging/Logging.ts
+++ b/logging/Logging.ts
@@ -1,0 +1,129 @@
+export const LOG_LEVELS = ["debug", "info", "warn", "error", "trace"] as const
+
+/**
+ * A level to be used when logging.
+ *
+ * `debug` = important stuff that doesn't matter in prod
+ *
+ * `info` = general log message
+ *
+ * `trace` = useful for tracing a list of steps up until a major issue occurs
+ *
+ * `warn` = a forewarning that a giant alien spider will trample this lostbe- I mean world
+ *
+ * `error` = for when an error occurs
+ */
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+/**
+ * A type that handles log messages and sends them somewhere (file, SQLite, Sentry, etc).
+ */
+export type LogHandler = (
+  label: string,
+  level: LogLevel,
+  message: string,
+  metadata?: object
+) => void
+
+/**
+ * A {@link LogHandler} which uses the built-in `console`.
+ *
+ * @param formatter A function to format the log message
+ */
+export const consoleLogHandler = (
+  formatter: (
+    label: string,
+    level: LogLevel,
+    message: string,
+    metadata?: object
+  ) => string = defaultFormatLogMessage
+): LogHandler => {
+  return (label, level, message, metadata) => {
+    console[level](formatter(label, level, message, metadata))
+  }
+}
+
+let logHandlers = [] as LogHandler[]
+
+/**
+ * An object for logging.
+ */
+export type Logger = Record<
+  LogLevel,
+  (message: string, metadata?: object) => void
+>
+
+/**
+ * Creates a function to log with a given label.
+ *
+ * Use this instead of `console.log` to log to many different sources at once.
+ *
+ * ```ts
+ * const log = logger("example")
+ * addLogHandler(consoleLogHandler())
+ * addLogHandler(rotatingLogFileHandler(...))
+ *
+ * // Logs to both the console and filesystem.
+ * log.info("Message", { key: "value" })
+ * ```
+ *
+ * You can add custom destinations by {@link LogHandler}s to {@link addLogHandler}.
+ *
+ * Additionally, each call to `log` can be passed a generic object of metadata.
+ * How this object is logged depends on the {@link LogHandler} handling the
+ * metadata. This metadata object ensures that no messy string interpolation is
+ * needed for log messages.
+ *
+ * @param label The label which identifies this logger, use this in different modules of the app to identify specific components.
+ * @returns A function which handles logging.
+ */
+export const logger = (label: string) => {
+  return LOG_LEVELS.reduce((acc, level) => {
+    acc[level] = (message: string, metadata?: object) => {
+      logHandlers.forEach((h) => h(label, level, message, metadata))
+    }
+    return acc
+  }, {} as Logger)
+}
+
+/**
+ * Adds a log handler that can handle and receive log messages via calls from
+ * the function created by `logger`.
+ *
+ * Use this function and {2link LogHandler} to add multiple log destinations
+ * (filesystem, Sentry, etc).
+ */
+export const addLogHandler = (handler: LogHandler) => {
+  logHandlers.push(handler)
+}
+
+/**
+ * Removes all active log handlers.
+ */
+export const resetLogHandlers = () => {
+  logHandlers = []
+}
+
+/**
+ * The default formatter for a log message.
+ */
+export const defaultFormatLogMessage = (
+  label: string,
+  level: LogLevel,
+  message: string,
+  metadata?: object
+) => {
+  const currentDate = new Date()
+  const levelEmoji = LEVEL_EMOJIS[level]
+  const stringifiedMetadata = JSON.stringify(metadata)
+  const metadataStr = stringifiedMetadata ? ` ${stringifiedMetadata}` : ""
+  return `${currentDate.toISOString()} [${label}] (${level.toUpperCase()} ${levelEmoji}) ${message}${metadataStr}\n`
+}
+
+const LEVEL_EMOJIS = {
+  debug: "🟢",
+  info: "🔵",
+  trace: "⚪️",
+  warn: "🟡",
+  error: "🔴"
+} satisfies Record<LogLevel, string>

--- a/logging/index.ts
+++ b/logging/index.ts
@@ -1,0 +1,1 @@
+export * from "./Logging"

--- a/test-helpers/FakeTimers.ts
+++ b/test-helpers/FakeTimers.ts
@@ -1,0 +1,16 @@
+/**
+ * Fakes jest timers for the duration of each test.
+ */
+export const fakeTimers = (
+  wrapRunPendingTimers: (
+    runPendingTimers: () => Promise<void>
+  ) => Promise<void> = async () => {} // NB: This needs to be act on the frontend.
+) => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(async () => {
+    await wrapRunPendingTimers(
+      async () => await jest.runOnlyPendingTimersAsync()
+    )
+    jest.useRealTimers()
+  })
+}


### PR DESCRIPTION
Adds the custom logging framework used on the frontend since it's something that we want to share. I've made some minor updates including adding a `trace` log level, and `createLogFunction` has now been replaces with a `logger` function that returns an object instead of a simple function. In essence:
```ts
// Before
const log = createLogFunction("test.label")
log("info", "Hello world", { key: "value" })

// After
const log = logger("test.label")
log.info("Hello world", { key: "value" })
```