### PR TITLE
Add observeSuccess and observeFailure

### DIFF
--- a/lib/Result.test.ts
+++ b/lib/Result.test.ts
@@ -115,7 +115,42 @@ describe("Result tests", () => {
   it("should observe promise results without modifying them", async () => {
     const currentFailure = promiseResult(failure("failed"))
     currentFailure.observe((result) => expect(result).toBe("failed"))
-    expect(currentFailure).toMatchObject(currentFailure)
+    const result = await currentFailure
+    expect(result).toMatchObject(failedResult)
+  })
+
+  it("should should not observe failure result when successful", async () => {
+    const observeFn = jest.fn()
+    let currentSuccess = promiseResult(success("passed"))
+    currentSuccess = currentSuccess.observeFailure(observeFn)
+    await currentSuccess
+    expect(observeFn).not.toHaveBeenCalled()
+  })
+
+  it("should should observe failure without modifying current result", async () => {
+    const observeFn = jest.fn()
+    const result1 = promiseResult(failure("failed"))
+    const result2 = result1.observeFailure(observeFn)
+    await result2
+    expect(result1).toBe(result2)
+    expect(observeFn).toHaveBeenCalledWith("failed")
+  })
+
+  it("should should not observe success result when failure", async () => {
+    const observeFn = jest.fn()
+    let currentFailure = promiseResult(failure("failed"))
+    currentFailure = currentFailure.observeSuccess(observeFn)
+    await currentFailure
+    expect(observeFn).not.toHaveBeenCalled()
+  })
+
+  it("should should observe failure without modifying current result", async () => {
+    const observeFn = jest.fn()
+    const result1 = promiseResult(success("passed"))
+    const result2 = result1.observeSuccess(observeFn)
+    await result2
+    expect(result1).toBe(result2)
+    expect(observeFn).toHaveBeenCalledWith("passed")
   })
 
   it("should allow promise results to be transformed", async () => {

--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -44,6 +44,27 @@ export class SuccessResult<Success, Failure> {
   }
 
   /**
+   * Runs the handler with the given success value if the result returns a
+   * successful value.
+   *
+   * @param handler a function to observe the value and perform a side effect.
+   */
+  observeSuccess(handler: (value: Success) => void) {
+    this.observe(handler)
+    return this
+  }
+
+  /**
+   * Runs the handler with the given success value if the result returns a
+   * failure value.
+   *
+   * @param handler a function to observe the value and perform a side effect.
+   */
+  observeFailure(_: (value: Failure) => void) {
+    return this
+  }
+
+  /**
    * Transforms the success result into an entirely new result.
    *
    * @param mapper a function to transform the current result into a new result.
@@ -125,6 +146,27 @@ export class FailureResult<Success, Failure> {
   }
 
   /**
+   * Runs the handler with the given success value if the result returns a
+   * successful value.
+   *
+   * @param handler a function to observe the value and perform a side effect.
+   */
+  observeSuccess(_: (value: Success) => void) {
+    return this
+  }
+
+  /**
+   * Runs the handler with the given success value if the result returns a
+   * failure value.
+   *
+   * @param handler a function to observe the value and perform a side effect.
+   */
+  observeFailure(handler: (value: Failure) => void) {
+    this.observe(handler)
+    return this
+  }
+
+  /**
    * Returns this result typecasted as the failure type unioned with the success
    * type and failure type returned from the given mapper function.
    */
@@ -143,8 +185,7 @@ export class FailureResult<Success, Failure> {
   flatMapFailure<NewSuccess, NewFailure>(
     mapper: (value: Failure) => AwaitableResult<NewSuccess, NewFailure>
   ): AnyResult<Success | NewSuccess, NewFailure> {
-    const result = mapper(this.value)
-    return result
+    return mapper(this.value)
   }
 
   /**
@@ -205,6 +246,28 @@ export class PromiseResult<Success, Failure> extends Promise<
    */
   observe(handler: (value: Success | Failure) => void) {
     this.then((result) => result.observe(handler))
+    return this
+  }
+
+  /**
+   * Waits for the promiseResult to settle, then runs the handler with the
+   * given success value if the result returns a successful value.
+   *
+   * @param handler a function to observe the value and perform a side effect.
+   */
+  observeSuccess(handler: (value: Success) => void) {
+    this.then((result) => result.observeSuccess(handler))
+    return this
+  }
+
+  /**
+   * Waits for the promiseResult to settle, then runs the handler with the
+   * given failure value if the result returns a failure value.
+   *
+   * @param handler a function to observe the value and perform a side effect.
+   */
+  observeFailure(handler: (value: Failure) => void) {
+    this.then((result) => result.observeFailure(handler))
     return this
   }
 


### PR DESCRIPTION
Adds an `observeSuccess` and `observeFailure` methods to `Result` since the base `observe` handler handles a union of the success and failure values. With these new methods, one could now define a handler that handles either the success or failure value in isolation.