### PR TITLE
Cleanup middleware

### DIFF
--- a/api/Middleware.ts
+++ b/api/Middleware.ts
@@ -42,9 +42,7 @@ export const chainMiddleware = (
   middleware1: TiFAPIMiddleware,
   ...middlewares: TiFAPIMiddleware[]
 ): TiFAPIMiddleware => {
-  return middlewares.reduce((acc, middleware) => {
-    return chain2Middleware(acc, middleware)
-  }, middleware1)
+  return middlewares.reduce(chain2Middleware, middleware1)
 }
 
 const chain2Middleware = (


### PR DESCRIPTION
A small cleanup to the middleware implementations. In particular, `chainMiddleware` previously called `array.reverse()` which modifies the input array. I fixed this by defining an internal `chain2Middleware` middleware which chains just 2 middleware at a time. Then I repeatedly call `chain2Middleware` inside of an `array.reduce` call which chains the accumulated middleware chain with the current middleware in the array. Ie. We can build a larger chained middleware by continuously chaining a chained middleware with a separate middleware.