### PR TITLE
Add promiseresultallsettled function

### DIFF
--- a/lib/Result.test.ts
+++ b/lib/Result.test.ts
@@ -1,4 +1,4 @@
-import { failure, promiseResult, promiseResultAll, promiseResultAllSettled, success } from "./Result"
+import { failure, promiseResult, promiseResultAllSettled, success } from "./Result"
 
 describe("Result tests", () => {
   const successResult = { status: "success" as const, value: "passed" as const }
@@ -220,5 +220,17 @@ describe("Result tests", () => {
     expect(
       await currentResult.inverted().flatMapSuccess(() => failure("failed" as const))
     ).toMatchObject({ status: "failure" as const, value: "failed" as const })
+  })
+  
+  it("should allow an array of promise results to resolve as one success result containing the array of success values", async () => {
+    expect(
+      await promiseResultAllSettled([promiseResult(success("success1" as const)), promiseResult(success("success2" as const))])
+    ).toMatchObject({ status: "success" as const, value: ["success1", "success2"] })
+  })
+  
+  it("should allow an array of promise results to resolve as one failure result containing the array of failure values", async () => {
+    expect(
+      await promiseResultAllSettled([promiseResult(success("success1" as const)), promiseResult(failure("failed1" as const)), promiseResult(failure("failed2" as const))])
+    ).toMatchObject({ status: "failure" as const, value: ["failed1", "failed2"] as const })
   })
 })

--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -419,6 +419,37 @@ export const promiseResult = <Success, Failure>(
 }
 
 /**
+ * Acts like Promise.all but for PromiseResult objects. If any of the PromiseResults
+ * resolve to a FailureResult, the entire operation is considered a failure. Otherwise,
+ * it aggregates all success values into an array.
+ *
+ * @param promises An array of PromiseResult objects.
+ * @returns A PromiseResult that either contains an array of all success values or the first failure encountered.
+ */
+export function promiseResultAllSettled<Success, Failure>(
+  promises: Array<PromiseResult<Success, Failure>>
+): PromiseResult<Success[], Failure[]> {
+  return new PromiseResult<Success[], Failure[]>((resolve) => {
+    Promise.all(promises)
+      .then(results => {
+        const successes: Success[] = [];
+        const failures: Failure[] = [];
+        for (const result of results) {
+          if (result.status === 'failure') {
+            failures.push(result.value);
+          } else {
+            successes.push(result.value);
+          }
+        }
+        if (failures.length > 0) {
+          return resolve(failure(failures))
+        }
+        resolve(success(successes));
+      })
+  });
+}
+
+/**
  * Creates a {@link SuccessResult} with the given value.
  */
 export function success(): SuccessResult<undefined, never>


### PR DESCRIPTION
Implements functions similar to promise.allsettled for results. Since we have to resolve all promises before determining if the operations are successes or failures, we can't really have a function similar to promise.all for results.