### PR TITLE
User Settings Models

### DIFF
--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -358,7 +358,7 @@ class _TiFAPIClass {
         endpoint: "/user/self/settings",
         body: request
       },
-      { status200: z.object({ updatedDateTime: StringDateSchema }) }
+      { status200: z.object({ version: z.number().nonnegative() }) }
     )
   }
 }

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,8 +1,13 @@
-import { UserHandleSchema, UserID, UserIDSchema } from "../domain-models/User"
+import {
+  UpdateUserSettingsRequest,
+  UserHandleSchema,
+  UserID,
+  UserIDSchema,
+  UserSettingsSchema
+} from "../domain-models/User"
 import {
   EventAttendeesPageSchema,
   EventRegion,
-  EventWhenBlockedByHostSchema,
   TrackableEventArrivalRegionsSchema
 } from "../domain-models/Event"
 import { z } from "zod"
@@ -22,6 +27,7 @@ import {
 } from "./models/Event"
 import { LocationCoordinate2D } from "domain-models/LocationCoordinate2D"
 import { jwtMiddleware } from "./Middleware"
+import { StringDateSchema } from "lib/Date"
 
 export const TEST_API_URL = new URL("http://localhost:8080")
 
@@ -325,6 +331,34 @@ class _TiFAPIClass {
       },
       { status200: EventsInAreaResponseSchema },
       signal
+    )
+  }
+
+  /**
+   * Returns the remote settings for the current user.
+   */
+  async userSettings() {
+    return await this.apiFetch(
+      {
+        method: "GET",
+        endpoint: "/user/self/settings"
+      },
+      { status200: UserSettingsSchema }
+    )
+  }
+
+  /**
+   * Saves the specified user settings and returns the timestamp that they
+   * were last updated.
+   */
+  async saveUserSettings(request: UpdateUserSettingsRequest) {
+    return await this.apiFetch(
+      {
+        method: "PATCH",
+        endpoint: "/user/self/settings",
+        body: request
+      },
+      { status200: z.object({ updatedDateTime: StringDateSchema }) }
     )
   }
 }

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -2,8 +2,7 @@ import {
   UpdateUserSettingsRequest,
   UserHandleSchema,
   UserID,
-  UserIDSchema,
-  UserSettingsSchema
+  UserIDSchema
 } from "../domain-models/User"
 import {
   EventAttendeesPageSchema,
@@ -15,6 +14,7 @@ import { TiFAPIEndpoint, TiFAPITransport, tifAPITransport } from "./Transport"
 import {
   UpdateCurrentUserProfileRequest,
   UserNotFoundResponseSchema,
+  UserSettingsResponseSchema,
   userTiFAPIErrorSchema
 } from "./models/User"
 import { tifAPIErrorSchema } from "./models/Error"
@@ -343,7 +343,7 @@ class _TiFAPIClass {
         method: "GET",
         endpoint: "/user/self/settings"
       },
-      { status200: UserSettingsSchema }
+      { status200: UserSettingsResponseSchema }
     )
   }
 

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -27,7 +27,7 @@ import {
 } from "./models/Event"
 import { LocationCoordinate2D } from "domain-models/LocationCoordinate2D"
 import { jwtMiddleware } from "./Middleware"
-import { StringDateSchema } from "lib/Date"
+import { StringDateSchema } from "../lib/Date"
 
 export const TEST_API_URL = new URL("http://localhost:8080")
 

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,8 +1,8 @@
 import {
-  UpdateUserSettingsRequest,
   UserHandleSchema,
   UserID,
-  UserIDSchema
+  UserIDSchema,
+  UserSettingsVersionSchema
 } from "../domain-models/User"
 import {
   EventAttendeesPageSchema,
@@ -13,6 +13,7 @@ import { z } from "zod"
 import { TiFAPIEndpoint, TiFAPITransport, tifAPITransport } from "./Transport"
 import {
   UpdateCurrentUserProfileRequest,
+  UpdateUserSettingsRequest,
   UserNotFoundResponseSchema,
   UserSettingsResponseSchema,
   userTiFAPIErrorSchema
@@ -27,7 +28,6 @@ import {
 } from "./models/Event"
 import { LocationCoordinate2D } from "domain-models/LocationCoordinate2D"
 import { jwtMiddleware } from "./Middleware"
-import { StringDateSchema } from "../lib/Date"
 
 export const TEST_API_URL = new URL("http://localhost:8080")
 
@@ -358,7 +358,7 @@ class _TiFAPIClass {
         endpoint: "/user/self/settings",
         body: request
       },
-      { status200: z.object({ version: z.number().nonnegative() }) }
+      { status200: z.object({ version: UserSettingsVersionSchema }) }
     )
   }
 }

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -1,4 +1,4 @@
-import { StringDateSchema } from "lib/Date"
+import { StringDateSchema } from "../../lib/Date"
 import {
   UserHandle,
   UserIDSchema,

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -22,6 +22,14 @@ export type UpdateCurrentUserProfileRequest = Partial<{
   handle: UserHandle
 }>
 
+export const UpdateUserSettingsRequestSchema = UserSettingsSchema.omit({
+  version: true
+}).partial()
+
+export type UpdateUserSettingsRequest = z.rInfer<
+  typeof UpdateUserSettingsRequestSchema
+>
+
 export type UserSettingsResponse = UserSettings
 
 export const UserSettingsResponseSchema = UserSettingsSchema

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -1,4 +1,9 @@
-import { UserHandle, UserIDSchema } from "../../domain-models/User"
+import { StringDateSchema } from "lib/Date"
+import {
+  UserHandle,
+  UserIDSchema,
+  UserSettingsSchema
+} from "../../domain-models/User"
 import { tifAPIErrorSchema } from "./Error"
 import { z } from "zod"
 
@@ -16,3 +21,7 @@ export type UpdateCurrentUserProfileRequest = Partial<{
   bio: string
   handle: UserHandle
 }>
+
+export const UserSettingsResponseSchema = UserSettingsSchema.omit({
+  updatedDateTime: true
+}).extend({ updatedDateTime: StringDateSchema.nullable() })

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -1,7 +1,7 @@
-import { StringDateSchema } from "../../lib/Date"
 import {
   UserHandle,
   UserIDSchema,
+  UserSettings,
   UserSettingsSchema
 } from "../../domain-models/User"
 import { tifAPIErrorSchema } from "./Error"
@@ -22,6 +22,6 @@ export type UpdateCurrentUserProfileRequest = Partial<{
   handle: UserHandle
 }>
 
-export const UserSettingsResponseSchema = UserSettingsSchema.omit({
-  updatedDateTime: true
-}).extend({ updatedDateTime: StringDateSchema.nullable() })
+export type UserSettingsResponse = UserSettings
+
+export const UserSettingsResponseSchema = UserSettingsSchema

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -100,6 +100,39 @@ export type BidirectionalUserRelations =
   | BlockedBidirectionalUserRelations
 
 /**
+ * A zod schema for {@link UserSettingsSchema}.
+ */
+export const UserSettingsSchema = z.object({
+  isAnalyticsEnabled: z.boolean(),
+  isCrashReportingEnabled: z.boolean(),
+  isEventNotificationsEnabled: z.boolean(),
+  isMentionsNotificationsEnabled: z.boolean(),
+  isChatNotificationsEnabled: z.boolean(),
+  isFriendRequestNotificationsEnabled: z.boolean(),
+  canShareArrivalStatus: z.boolean(),
+  updatedDateTime: z.date().nullable()
+})
+
+/**
+ * A type representing a user's settings.
+ */
+export type UserSettings = z.infer<typeof UserSettingsSchema>
+
+/**
+ * The default user settings, which enables all fields.
+ */
+export const DEFAULT_USER_SETTINGS = {
+  isAnalyticsEnabled: true,
+  isCrashReportingEnabled: true,
+  isEventNotificationsEnabled: true,
+  isMentionsNotificationsEnabled: true,
+  isChatNotificationsEnabled: true,
+  isFriendRequestNotificationsEnabled: true,
+  canShareArrivalStatus: true,
+  updatedDateTime: null
+} as const satisfies UserSettings
+
+/**
  * An reason that a user handle's raw text was unable to be parsed.
  */
 export type UserHandleParsingError = "bad-format" | "empty" | "too-long"

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -110,7 +110,7 @@ export const UserSettingsSchema = z.object({
   isChatNotificationsEnabled: z.boolean(),
   isFriendRequestNotificationsEnabled: z.boolean(),
   canShareArrivalStatus: z.boolean(),
-  updatedDateTime: z.date().nullable()
+  version: z.number().nonnegative()
 })
 
 /**
@@ -129,11 +129,11 @@ export const DEFAULT_USER_SETTINGS = {
   isChatNotificationsEnabled: true,
   isFriendRequestNotificationsEnabled: true,
   canShareArrivalStatus: true,
-  updatedDateTime: null
-} as const satisfies UserSettings
+  version: 0
+} as Readonly<UserSettings>
 
 export const UpdateUserSettingsRequestSchema = UserSettingsSchema.omit({
-  updatedDateTime: true
+  version: true
 }).partial()
 
 export type UpdateUserSettingsRequest = z.rInfer<

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -132,6 +132,14 @@ export const DEFAULT_USER_SETTINGS = {
   updatedDateTime: null
 } as const satisfies UserSettings
 
+export const UpdateUserSettingsRequestSchema = UserSettingsSchema.omit({
+  updatedDateTime: true
+}).partial()
+
+export type UpdateUserSettingsRequest = z.rInfer<
+  typeof UpdateUserSettingsRequestSchema
+>
+
 /**
  * An reason that a user handle's raw text was unable to be parsed.
  */

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -99,6 +99,10 @@ export type BidirectionalUserRelations =
   | UnblockedBidirectionalUserRelations
   | BlockedBidirectionalUserRelations
 
+export const UserSettingsVersionSchema = z.number().nonnegative()
+
+export type UserSettingsVersion = z.infer<typeof UserSettingsVersionSchema>
+
 /**
  * A zod schema for {@link UserSettingsSchema}.
  */
@@ -110,13 +114,13 @@ export const UserSettingsSchema = z.object({
   isChatNotificationsEnabled: z.boolean(),
   isFriendRequestNotificationsEnabled: z.boolean(),
   canShareArrivalStatus: z.boolean(),
-  version: z.number().nonnegative()
+  version: UserSettingsVersionSchema
 })
 
 /**
  * A type representing a user's settings.
  */
-export type UserSettings = z.infer<typeof UserSettingsSchema>
+export type UserSettings = z.rInfer<typeof UserSettingsSchema>
 
 /**
  * The default user settings, which enables all fields.
@@ -131,14 +135,6 @@ export const DEFAULT_USER_SETTINGS = {
   canShareArrivalStatus: true,
   version: 0
 } as Readonly<UserSettings>
-
-export const UpdateUserSettingsRequestSchema = UserSettingsSchema.omit({
-  version: true
-}).partial()
-
-export type UpdateUserSettingsRequest = z.rInfer<
-  typeof UpdateUserSettingsRequestSchema
->
 
 /**
  * An reason that a user handle's raw text was unable to be parsed.


### PR DESCRIPTION
Adds endpoints for the user settings, and migrates the models over from the backend. Specifically based on [this](https://github.com/tifapp/FitnessProjectBackend/pull/223) PR. I also added `canShareArrivalStatus` which is obviously for whether or not we need to post arrivals to the backend.