### PR TITLE
Update saveUserSettings API response

### DIFF
--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,9 +1,4 @@
-import {
-  UserHandleSchema,
-  UserID,
-  UserIDSchema,
-  UserSettingsVersionSchema
-} from "../domain-models/User"
+import { UserHandleSchema, UserID, UserIDSchema } from "../domain-models/User"
 import {
   EventAttendeesPageSchema,
   EventRegion,
@@ -348,8 +343,7 @@ class _TiFAPIClass {
   }
 
   /**
-   * Saves the specified user settings and returns the timestamp that they
-   * were last updated.
+   * Saves the specified user settings and returns the updated user settings.
    */
   async saveUserSettings(request: UpdateUserSettingsRequest) {
     return await this.apiFetch(
@@ -358,7 +352,7 @@ class _TiFAPIClass {
         endpoint: "/user/self/settings",
         body: request
       },
-      { status200: z.object({ version: UserSettingsVersionSchema }) }
+      { status200: UserSettingsResponseSchema }
     )
   }
 }

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -119,11 +119,20 @@ export const UserSettingsSchema = z.object({
 
 /**
  * A type representing a user's settings.
+ *
+ * Each instance of settings has a version number which is used for client
+ * and server side synchronization. When the client refreshes its settings,
+ * it compares its local version number with the version number of the server.
+ * If the server version number is higher than the client version number, then
+ * the client switches to using the server version number. If the client
+ * version number is higher than the server's, then the client sends its copy
+ * of the settings to the server.
  */
 export type UserSettings = z.rInfer<typeof UserSettingsSchema>
 
 /**
- * The default user settings, which enables all fields.
+ * The default user settings which enables all fields, and sets the version
+ * number to zero.
  */
 export const DEFAULT_USER_SETTINGS = {
   isAnalyticsEnabled: true,


### PR DESCRIPTION
Updates the API response of `saveUserSettings` to return the updated settings instead of just the version number. This makes it easy to return the proper settings to the client in the event of 2 simultaneous settings updates on the server.