### PR TITLE
Run ticket link github action on pr open & edit, and allow urls in pr description and npm run pr script.

### DIFF
--- a/.github/workflows/link-ticket-on-pull-request.yml
+++ b/.github/workflows/link-ticket-on-pull-request.yml
@@ -2,13 +2,13 @@ name: Attach PR to Trello Ticket
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
     branches:
       - main
 
 jobs:
   link-ticket:
-    uses: tifapp/TiFShared/.github/workflows/link-ticket.yml@main
+    uses: tifapp/TiFShared/.github/workflows/link-ticket.yml@auto-ticket-link-and-pr
     secrets: inherit
     with:
       pullRequestCommentsUrl: ${{ github.event.pull_request.comments_url }}

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -55,12 +55,8 @@ jobs:
         run: |
           BRANCH_NAME="${{ inputs.headRef }}"
           PR_BODY=$(echo "$ENCODED_BODY" | base64 --decode)
-          # Extracting ID from branch name or PR body
-          TICKET_ID=$(echo "$BRANCH_NAME" | grep -oP '(?i:task)_\K[A-Za-z0-9]+' || echo "$PR_BODY" | grep -oP '(?i:task)_\K[A-Za-z0-9]+')
-          # Extracting ID from URL in PR body
-          TICKET_ID_FROM_URL=$(echo "$PR_BODY" | grep -oP 'https://trello\.com/c/\K[A-Za-z0-9]+(?=/|\?|$)')
-          # Using the first non-empty result
-          TICKET_ID="${TICKET_ID:-$TICKET_ID_FROM_URL}"
+          # Attempt to extract ID from branch name using task_xxx pattern
+          TICKET_ID=$(echo "$BRANCH_NAME" | grep -oP '(?i:task)_\K[A-Za-z0-9]+' || echo "$PR_BODY" | grep -oP '(?i:task)_\K[A-Za-z0-9]+' || echo "$PR_BODY" | grep -oP 'https://trello\.com/c/\K[A-Za-z0-9]+(?=/|\?|$)' || echo "")
           if [[ -z "$TICKET_ID" ]]; then
             echo "No ticket ID found in branch name or PR body."
             exit 1

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -55,15 +55,19 @@ jobs:
         run: |
           BRANCH_NAME="${{ inputs.headRef }}"
           PR_BODY=$(echo "$ENCODED_BODY" | base64 --decode)
-          # Using regex to extract card ID that starts with 'task_' followed by alphanumeric characters
-          TRELLO_TICKET_ID=$(echo "$BRANCH_NAME" | grep -oP '(?i:task)_\K[A-Za-z0-9]+' || echo "$PR_BODY" | grep -oP '(?i:task)_\K[A-Za-z0-9]+' || echo "")
-          if [[ -z "$TRELLO_TICKET_ID" ]]; then
+          # Extracting ID from branch name or PR body
+          TICKET_ID=$(echo "$BRANCH_NAME" | grep -oP '(?i:task)_\K[A-Za-z0-9]+' || echo "$PR_BODY" | grep -oP '(?i:task)_\K[A-Za-z0-9]+')
+          # Extracting ID from URL in PR body
+          TICKET_ID_FROM_URL=$(echo "$PR_BODY" | grep -oP 'https://trello\.com/c/\K[A-Za-z0-9]+(?=/|\?|$)')
+          # Using the first non-empty result
+          TICKET_ID="${TICKET_ID:-$TICKET_ID_FROM_URL}"
+          if [[ -z "$TICKET_ID" ]]; then
             echo "No ticket ID found in branch name or PR body."
             exit 1
           else
-            echo "Found Ticket ID: $TRELLO_TICKET_ID"
+            echo "Found Ticket ID: $TICKET_ID"
             echo "::set-output name=skip::false"
-            echo "::set-output name=ticket_id::$TRELLO_TICKET_ID"
+            echo "::set-output name=ticket_id::$TICKET_ID"
           fi
 
   link-ticket:

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Then link the utils package to your main project:
 ```bash
 npm link TiFShared
 ```
-* Important: Package-name is case-sensitive
+* Important: Package name is case-sensitive
 
 ### Step 3: Verify the Link
 

--- a/npm-scripts/auto-pr-util.test.ts
+++ b/npm-scripts/auto-pr-util.test.ts
@@ -38,6 +38,16 @@ describe("Auto PR Script Tests", () => {
   })
 
   describe('getRawIdFromTicketId', () => {
+    it('extracts the ticket ID when it is in short url format', () => {
+      const ticketId = 'https://trello.com/c/123';
+      expect(getRawIdFromTicketId(ticketId)).toBe('123');
+    });
+    
+    it('extracts the ticket ID when it is in long url format', () => {
+      const ticketId = 'https://trello.com/c/123/098-task-name';
+      expect(getRawIdFromTicketId(ticketId)).toBe('123');
+    });
+    
     it('extracts the ticket ID when it is at the beginning of the string', () => {
       const ticketId = 'TASK_123-bug-fix';
       expect(getRawIdFromTicketId(ticketId)).toBe('123');

--- a/npm-scripts/auto-pr-util.ts
+++ b/npm-scripts/auto-pr-util.ts
@@ -3,7 +3,7 @@ import { logger } from "../logging/Logging.ts";
 const log = logger("auto-pr-script")
 
 export const getRawIdFromTicketId = (ticketId: string) => {
-    const match = ticketId.match(/(?<=task_)\w+/i);
+    const match = ticketId.match(/(?<=task_)\w+|(?<=trello\.com\/c\/)(\w+)(?=\/|\?|$)/i);
     return match ? match[0] : null;
 };
 


### PR DESCRIPTION
+fix typo in readme

Now "npm run pr TASK_xxxxx" works as well as "npm run pr https://trello.com/c/xxxxx"

Also when opening/editing a PR you can add the ticket id TASK_xxxxx or trello link https://trello.com/c/xxxxx, and the github action will trigger and link the ticket to the pr.

https://trello.com/c/y6zY4kQW/545-github-trello-integration