### PR TITLE
Update Settings Types

### DIFF
--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -1,9 +1,5 @@
-import {
-  UserHandle,
-  UserIDSchema,
-  UserSettings,
-  UserSettingsSchema
-} from "../../domain-models/User"
+import { UserSettings, UserSettingsSchema } from "../../domain-models/Settings"
+import { UserHandle, UserIDSchema } from "../../domain-models/User"
 import { tifAPIErrorSchema } from "./Error"
 import { z } from "zod"
 

--- a/domain-models/Event.ts
+++ b/domain-models/Event.ts
@@ -182,6 +182,18 @@ export type TrackableEventArrivalRegions = z.rInfer<
   typeof TrackableEventArrivalRegionsSchema
 >
 
+export const EventCalendarWeekdaySchema = z.union([
+  z.literal("sunday"),
+  z.literal("monday"),
+  z.literal("tuesday"),
+  z.literal("wednesday"),
+  z.literal("thursday"),
+  z.literal("friday"),
+  z.literal("saturday")
+])
+
+export type EventCalendarWeekday = z.infer<typeof EventCalendarWeekdaySchema>
+
 /**
  * A handle that users can reference other events with.
  *

--- a/domain-models/Event.ts
+++ b/domain-models/Event.ts
@@ -182,18 +182,6 @@ export type TrackableEventArrivalRegions = z.rInfer<
   typeof TrackableEventArrivalRegionsSchema
 >
 
-export const EventCalendarWeekdaySchema = z.union([
-  z.literal("sunday"),
-  z.literal("monday"),
-  z.literal("tuesday"),
-  z.literal("wednesday"),
-  z.literal("thursday"),
-  z.literal("friday"),
-  z.literal("saturday")
-])
-
-export type EventCalendarWeekday = z.infer<typeof EventCalendarWeekdaySchema>
-
 /**
  * A handle that users can reference other events with.
  *

--- a/domain-models/Settings.test.ts
+++ b/domain-models/Settings.test.ts
@@ -1,19 +1,23 @@
-import { toggleSettingsTrigger } from "./Settings"
+import { toggleSettingsTriggerId } from "./Settings"
 
 describe("Settings tests", () => {
-  describe("ToggleTriggerOption tests", () => {
+  describe("ToggleSettingsTriggerID tests", () => {
     it("should filter the trigger from the set if toggle value is false", () => {
-      const triggers = toggleSettingsTrigger(["hello", "world"], "hello", false)
+      const triggers = toggleSettingsTriggerId(
+        ["hello", "world"],
+        "hello",
+        false
+      )
       expect(triggers.includes("hello")).toEqual(false)
     })
 
     it("should add the trigger to the set if toggle value is true", () => {
-      const triggers = toggleSettingsTrigger(["world"], "hello", true)
+      const triggers = toggleSettingsTriggerId(["world"], "hello", true)
       expect(triggers.includes("hello")).toEqual(true)
     })
 
     it("should not add the trigger if the toggle value is true and the trigger is already in the set", () => {
-      const triggers = toggleSettingsTrigger(["hello"], "hello", true)
+      const triggers = toggleSettingsTriggerId(["hello"], "hello", true)
       expect(triggers).toEqual(["hello"])
     })
   })

--- a/domain-models/Settings.test.ts
+++ b/domain-models/Settings.test.ts
@@ -1,0 +1,20 @@
+import { toggleSettingsTrigger } from "./Settings"
+
+describe("Settings tests", () => {
+  describe("ToggleTriggerOption tests", () => {
+    it("should filter the trigger from the set if toggle value is false", () => {
+      const triggers = toggleSettingsTrigger(["hello", "world"], "hello", false)
+      expect(triggers.includes("hello")).toEqual(false)
+    })
+
+    it("should add the trigger to the set if toggle value is true", () => {
+      const triggers = toggleSettingsTrigger(["world"], "hello", true)
+      expect(triggers.includes("hello")).toEqual(true)
+    })
+
+    it("should not add the trigger if the toggle value is true and the trigger is already in the set", () => {
+      const triggers = toggleSettingsTrigger(["hello"], "hello", true)
+      expect(triggers).toEqual(["hello"])
+    })
+  })
+})

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -31,8 +31,8 @@ export const PushNotificationTriggerIDSchema = z.union([
   z.literal("friend-request-received"),
   z.literal("friend-request-accepted"),
   z.literal("user-entered-region"),
-  z.literal("event-started"),
-  z.literal("event-periodic-update"),
+  z.literal("event-attendance-headcount"),
+  z.literal("event-periodic-arrivals"),
   z.literal("event-starting-soon"),
   z.literal("event-started"),
   z.literal("event-ended"),
@@ -56,12 +56,12 @@ export const PushNotificationTriggerIDSchema = z.union([
  * `"user-entered-region"` -> Triggers when the user enters the arrival radius
  * for the event within the tracking period.
  *
- * `"event-started-arrivals"` -> Triggers when an event starts with an update
+ * `"event-attendance-headcount"` -> Triggers when an event starts with an update
  * on the headcount of attendees who are at the event.
  *
- * `"event-periodic-arrivals-update"` -> Triggers at periodic intervals
- * throughout the duration of an event with updates on the arrival statuses
- * of all participants.
+ * `"event-periodic-arrivals"` -> Triggers at periodic intervals throughout the
+ * duration of an event with updates on the arrival statuses of all
+ * participants.
  *
  * `"event-starting-soon"` -> Triggers x minutes (user-specified) before the event starts.
  *
@@ -133,8 +133,8 @@ export const DEFAULT_USER_SETTINGS = {
     "friend-request-received",
     "friend-request-accepted",
     "user-entered-region",
-    "event-started",
-    "event-periodic-update",
+    "event-attendance-headcount",
+    "event-periodic-arrivals",
     "event-starting-soon",
     "event-started",
     "event-ended",

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -41,6 +41,74 @@ export type CustomizeableFontFamily = z.infer<
   typeof CustomizeableFontFamilySchema
 >
 
+export const EventChangeNotificationTriggerSchema = z.union([
+  z.literal("name-changed"),
+  z.literal("description-changed"),
+  z.literal("time-changed"),
+  z.literal("location-changed"),
+  z.literal("event-cancelled")
+])
+
+/**
+ * A string descriptor for a trigger when a push notification should be sent to
+ * the user due to information about an event changing or being cancelled.
+ *
+ * `"name-changed"` -> Triggers when the event name changes.
+ *
+ * `"description-changed"` -> Triggers when the event description changes.
+ *
+ * `"time-changed"` -> Triggers when either the start time or duration of the
+ * event changes.
+ *
+ * `"location-changed"` -> Triggers when the event location changes.
+ *
+ * `"event-cancelled"` -> Triggers when the event is cancelled.
+ */
+export type EventChangeNotificationTrigger = z.infer<
+  typeof EventChangeNotificationTriggerSchema
+>
+
+export const FriendNotificationTriggerSchema = z.union([
+  z.literal("friend-request-received"),
+  z.literal("friend-request-accepted")
+])
+
+/**
+ * A string descriptor for a trigger when a push notification should be sent to
+ * the user due to actions taken by sending friend requests.
+ *
+ * `"friend-request-received"` -> Triggers when the user received a friend
+ * request from another user.
+ *
+ * `"friend-request-accepted"` -> Triggers when another user accpets the user's
+ * friend request.
+ */
+export type FriendNotificationTrigger = z.infer<
+  typeof FriendNotificationTriggerSchema
+>
+
+export const EventArrivalNotificationTriggerSchema = z.union([
+  z.literal("user-entered-region"),
+  z.literal("event-started"),
+  z.literal("event-periodic-update")
+])
+
+/**
+ * A string descriptor for a trigger when a push notification should be sent to
+ * the user due to event participants arriving at their respective event.
+ *
+ * `"user-entered-region"` -> Triggers when the user enters the arrival radius
+ * for the event within the tracking period.
+ *
+ * `"event-started"` -> Triggers when an event starts.
+ *
+ * `"event-periodic-update"` -> Triggers at periodic intervals throughout the
+ * duration of an event.
+ */
+export type EventArrivalNotificationTrigger = z.infer<
+  typeof EventArrivalNotificationTriggerSchema
+>
+
 /**
  * A zod schema for {@link UserSettingsSchema}.
  */
@@ -50,7 +118,14 @@ export const UserSettingsSchema = z.object({
   isEventNotificationsEnabled: z.boolean(),
   isMentionsNotificationsEnabled: z.boolean(),
   isChatNotificationsEnabled: z.boolean(),
-  isFriendRequestNotificationsEnabled: z.boolean(),
+  isProfileNotificationsEnabled: z.boolean(),
+  eventArrivalNotificationTriggers: z.array(
+    EventArrivalNotificationTriggerSchema
+  ),
+  eventChangeNotificationTriggers: z.array(
+    EventChangeNotificationTriggerSchema
+  ),
+  friendNotificationTriggers: z.array(FriendNotificationTriggerSchema),
   canShareArrivalStatus: z.boolean(),
   fontFamily: CustomizeableFontFamilySchema,
   userInterfaceStyle: UserInterfaceStyleSchema,
@@ -82,7 +157,21 @@ export const DEFAULT_USER_SETTINGS = {
   isEventNotificationsEnabled: true,
   isMentionsNotificationsEnabled: true,
   isChatNotificationsEnabled: true,
-  isFriendRequestNotificationsEnabled: true,
+  isProfileNotificationsEnabled: true,
+  eventChangeNotificationTriggers: [
+    "time-changed",
+    "event-cancelled",
+    "location-changed"
+  ],
+  eventArrivalNotificationTriggers: [
+    "event-started",
+    "event-periodic-update",
+    "user-entered-region"
+  ],
+  friendNotificationTriggers: [
+    "friend-request-received",
+    "friend-request-accepted"
+  ],
   canShareArrivalStatus: true,
   fontFamily: "open-sans",
   userInterfaceStyle: "system",

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -24,92 +24,64 @@ export const EventCalendarLayoutIDSchema = z.union([
 
 export type EventCalendarLayoutID = z.infer<typeof EventCalendarLayoutIDSchema>
 
-export const EventChangeNotificationTriggerIDSchema = z.union([
-  z.literal("name-changed"),
-  z.literal("description-changed"),
-  z.literal("time-changed"),
-  z.literal("location-changed"),
+/**
+ * A zod schema for {@link PushNotificationTriggerID}.
+ */
+export const PushNotificationTriggerIDSchema = z.union([
+  z.literal("friend-request-received"),
+  z.literal("friend-request-accepted"),
+  z.literal("user-entered-region"),
+  z.literal("event-started"),
+  z.literal("event-periodic-update"),
+  z.literal("event-starting-soon"),
+  z.literal("event-started"),
+  z.literal("event-ended"),
+  z.literal("event-name-changed"),
+  z.literal("event-description-changed"),
+  z.literal("event-time-changed"),
+  z.literal("event-location-changed"),
   z.literal("event-cancelled")
 ])
 
 /**
- * A string descriptor for a trigger when a push notification should be sent to
- * the user due to information about an event changing or being cancelled.
- *
- * `"name-changed"` -> Triggers when the event name changes.
- *
- * `"description-changed"` -> Triggers when the event description changes.
- *
- * `"time-changed"` -> Triggers when either the start time or duration of the
- * event changes.
- *
- * `"location-changed"` -> Triggers when the event location changes.
- *
- * `"event-cancelled"` -> Triggers when the event is cancelled.
- */
-export type EventChangeNotificationTriggerID = z.infer<
-  typeof EventChangeNotificationTriggerIDSchema
->
-
-export const EventTimeNotificationTriggerIDSchema = z.union([
-  z.literal("before-event"),
-  z.literal("event-started"),
-  z.literal("event-ended")
-])
-
-/**
- * A string descriptor for a trigger when a push notification should be sent to
- * the user due to the timing of the event.
- *
- * `"before-event"` -> Triggers x minutes (user-specified) before the event starts.
- *
- * `"event-started"` -> Triggers when the event starts.
- *
- * `"event-ended"` -> Triggers when the event ends.
- */
-export type EventTimeNotificationTriggerID = z.infer<
-  typeof EventTimeNotificationTriggerIDSchema
->
-
-export const FriendNotificationTriggerIDSchema = z.union([
-  z.literal("friend-request-received"),
-  z.literal("friend-request-accepted")
-])
-
-/**
- * A string descriptor for a trigger when a push notification should be sent to
- * the user due to actions taken by sending friend requests.
+ * A string id for a trigger when a push notification should be sent to
+ * the user.
  *
  * `"friend-request-received"` -> Triggers when the user received a friend
  * request from another user.
  *
  * `"friend-request-accepted"` -> Triggers when another user accpets the user's
  * friend request.
- */
-export type FriendNotificationTriggerID = z.infer<
-  typeof FriendNotificationTriggerIDSchema
->
-
-export const EventArrivalNotificationTriggerIDSchema = z.union([
-  z.literal("user-entered-region"),
-  z.literal("event-started"),
-  z.literal("event-periodic-update")
-])
-
-/**
- * A string descriptor for a trigger when a push notification should be sent to
- * the user due to event participants arriving at their respective event.
  *
  * `"user-entered-region"` -> Triggers when the user enters the arrival radius
  * for the event within the tracking period.
  *
- * `"event-started"` -> Triggers when an event starts.
+ * `"event-started-arrivals"` -> Triggers when an event starts with an update
+ * on the headcount of attendees who are at the event.
  *
- * `"event-periodic-update"` -> Triggers at periodic intervals throughout the
- * duration of an event.
+ * `"event-periodic-arrivals-update"` -> Triggers at periodic intervals
+ * throughout the duration of an event with updates on the arrival statuses
+ * of all participants.
+ *
+ * `"event-starting-soon"` -> Triggers x minutes (user-specified) before the event starts.
+ *
+ * `"event-started"` -> Triggers when the event starts.
+ *
+ * `"event-ended"` -> Triggers when the event ends.
+ *
+ * `"event-name-changed"` -> Triggers when the event name changes.
+ *
+ * `"event-description-changed"` -> Triggers when the event description changes.
+ *
+ * `"event-time-changed"` -> Triggers when either the start time or duration of the
+ * event changes.
+ *
+ * `"event-location-changed"` -> Triggers when the event location changes.
+ *
+ * `"event-cancelled"` -> Triggers when the event is cancelled.
  */
-export type EventArrivalNotificationTriggerID = z.infer<
-  typeof EventArrivalNotificationTriggerIDSchema
+export type PushNotificationTriggerID = z.infer<
+  typeof PushNotificationTriggerIDSchema
 >
 
 /**
@@ -130,16 +102,7 @@ export const toggleSettingsTriggerId = <TriggerID extends string>(
 export const UserSettingsSchema = z.object({
   isAnalyticsEnabled: z.boolean(),
   isCrashReportingEnabled: z.boolean(),
-  eventArrivalNotificationTriggerIds: z.array(
-    EventArrivalNotificationTriggerIDSchema
-  ),
-  eventChangeNotificationTriggerIds: z.array(
-    EventChangeNotificationTriggerIDSchema
-  ),
-  eventTimeNotificationTriggerIds: z.array(
-    EventTimeNotificationTriggerIDSchema
-  ),
-  friendNotificationTriggerIds: z.array(FriendNotificationTriggerIDSchema),
+  pushNotificationTriggerIds: z.array(PushNotificationTriggerIDSchema),
   canShareArrivalStatus: z.boolean(),
   eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
   eventCalendarDefaultLayout: EventCalendarLayoutIDSchema,
@@ -166,20 +129,20 @@ export type UserSettings = z.rInfer<typeof UserSettingsSchema>
 export const DEFAULT_USER_SETTINGS = {
   isAnalyticsEnabled: true,
   isCrashReportingEnabled: true,
-  eventChangeNotificationTriggerIds: [
-    "time-changed",
-    "event-cancelled",
-    "location-changed"
-  ],
-  eventArrivalNotificationTriggerIds: [
+  pushNotificationTriggerIds: [
+    "friend-request-received",
+    "friend-request-accepted",
+    "user-entered-region",
     "event-started",
     "event-periodic-update",
-    "user-entered-region"
-  ],
-  eventTimeNotificationTriggerIds: ["before-event", "event-started"],
-  friendNotificationTriggerIds: [
-    "friend-request-received",
-    "friend-request-accepted"
+    "event-starting-soon",
+    "event-started",
+    "event-ended",
+    "event-name-changed",
+    "event-description-changed",
+    "event-time-changed",
+    "event-location-changed",
+    "event-cancelled"
   ],
   canShareArrivalStatus: true,
   eventCalendarStartOfWeekDay: "monday",

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -130,10 +130,6 @@ export const toggleSettingsTriggerId = <TriggerID extends string>(
 export const UserSettingsSchema = z.object({
   isAnalyticsEnabled: z.boolean(),
   isCrashReportingEnabled: z.boolean(),
-  isEventNotificationsEnabled: z.boolean(),
-  isMentionsNotificationsEnabled: z.boolean(),
-  isChatNotificationsEnabled: z.boolean(),
-  isProfileNotificationsEnabled: z.boolean(),
   eventArrivalNotificationTriggerIds: z.array(
     EventArrivalNotificationTriggerIDSchema
   ),
@@ -170,10 +166,6 @@ export type UserSettings = z.rInfer<typeof UserSettingsSchema>
 export const DEFAULT_USER_SETTINGS = {
   isAnalyticsEnabled: true,
   isCrashReportingEnabled: true,
-  isEventNotificationsEnabled: true,
-  isMentionsNotificationsEnabled: true,
-  isChatNotificationsEnabled: true,
-  isProfileNotificationsEnabled: true,
   eventChangeNotificationTriggerIds: [
     "time-changed",
     "event-cancelled",

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -68,6 +68,26 @@ export type EventChangeNotificationTrigger = z.infer<
   typeof EventChangeNotificationTriggerSchema
 >
 
+export const EventTimeNotificationTriggerSchema = z.union([
+  z.literal("before-event"),
+  z.literal("event-started"),
+  z.literal("event-ended")
+])
+
+/**
+ * A string descriptor for a trigger when a push notification should be sent to
+ * the user due to the timing of the event.
+ *
+ * `"before-event"` -> Triggers x minutes (user-specified) before the event starts.
+ *
+ * `"event-started"` -> Triggers when the event starts.
+ *
+ * `"event-ended"` -> Triggers when the event ends.
+ */
+export type EventTimeNotificationTrigger = z.infer<
+  typeof EventTimeNotificationTriggerSchema
+>
+
 export const FriendNotificationTriggerSchema = z.union([
   z.literal("friend-request-received"),
   z.literal("friend-request-accepted")
@@ -125,6 +145,7 @@ export const UserSettingsSchema = z.object({
   eventChangeNotificationTriggers: z.array(
     EventChangeNotificationTriggerSchema
   ),
+  eventTimeNotificationTriggers: z.array(EventTimeNotificationTriggerSchema),
   friendNotificationTriggers: z.array(FriendNotificationTriggerSchema),
   canShareArrivalStatus: z.boolean(),
   fontFamily: CustomizeableFontFamilySchema,
@@ -168,6 +189,7 @@ export const DEFAULT_USER_SETTINGS = {
     "event-periodic-update",
     "user-entered-region"
   ],
+  eventTimeNotificationTriggers: ["before-event", "event-started"],
   friendNotificationTriggers: [
     "friend-request-received",
     "friend-request-accepted"

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -130,6 +130,18 @@ export type EventArrivalNotificationTrigger = z.infer<
 >
 
 /**
+ * A utility to toggle on or off an element in a setttings trigger set.
+ */
+export const toggleSettingsTrigger = <Trigger extends string>(
+  triggers: Trigger[],
+  trigger: Trigger,
+  isEnabled: boolean
+) => {
+  const filteredTriggers = triggers.filter((t) => t !== trigger)
+  return isEnabled ? filteredTriggers.concat(trigger) : filteredTriggers
+}
+
+/**
  * A zod schema for {@link UserSettingsSchema}.
  */
 export const UserSettingsSchema = z.object({

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -71,7 +71,7 @@ export type EventTimeNotificationTriggerID = z.infer<
   typeof EventTimeNotificationTriggerIDSchema
 >
 
-export const FriendNotificationTriggerSchemaID = z.union([
+export const FriendNotificationTriggerIDSchema = z.union([
   z.literal("friend-request-received"),
   z.literal("friend-request-accepted")
 ])
@@ -87,7 +87,7 @@ export const FriendNotificationTriggerSchemaID = z.union([
  * friend request.
  */
 export type FriendNotificationTriggerID = z.infer<
-  typeof FriendNotificationTriggerSchemaID
+  typeof FriendNotificationTriggerIDSchema
 >
 
 export const EventArrivalNotificationTriggerIDSchema = z.union([
@@ -139,7 +139,7 @@ export const UserSettingsSchema = z.object({
   eventTimeNotificationTriggerIds: z.array(
     EventTimeNotificationTriggerIDSchema
   ),
-  friendNotificationTriggerIds: z.array(FriendNotificationTriggerSchemaID),
+  friendNotificationTriggerIds: z.array(FriendNotificationTriggerIDSchema),
   canShareArrivalStatus: z.boolean(),
   eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
   eventCalendarDefaultLayout: EventCalendarLayoutIDSchema,

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -1,0 +1,92 @@
+import { z } from "zod"
+
+export const UserSettingsVersionSchema = z.number().nonnegative()
+
+export type UserSettingsVersion = z.infer<typeof UserSettingsVersionSchema>
+
+export const EventCalendarWeekdaySchema = z.union([
+  z.literal("sunday"),
+  z.literal("monday"),
+  z.literal("tuesday"),
+  z.literal("wednesday"),
+  z.literal("thursday"),
+  z.literal("friday"),
+  z.literal("saturday")
+])
+
+export type EventCalendarWeekday = z.infer<typeof EventCalendarWeekdaySchema>
+
+export const EventCalendarLayoutSchema = z.union([
+  z.literal("single-day-layout"),
+  z.literal("week-layout"),
+  z.literal("month-layout")
+])
+
+export type EventCalendarLayout = z.infer<typeof EventCalendarLayoutSchema>
+
+export const UserInterfaceStyleSchema = z.union([
+  z.literal("light"),
+  z.literal("dark"),
+  z.literal("system")
+])
+
+export type UserInterfaceStyle = z.infer<typeof UserInterfaceStyleSchema>
+
+export const CustomizeableFontFamilySchema = z.union([
+  z.literal("open-sans"),
+  z.literal("open-dyslexic")
+])
+
+export type CustomizeableFontFamily = z.infer<
+  typeof CustomizeableFontFamilySchema
+>
+
+/**
+ * A zod schema for {@link UserSettingsSchema}.
+ */
+export const UserSettingsSchema = z.object({
+  isAnalyticsEnabled: z.boolean(),
+  isCrashReportingEnabled: z.boolean(),
+  isEventNotificationsEnabled: z.boolean(),
+  isMentionsNotificationsEnabled: z.boolean(),
+  isChatNotificationsEnabled: z.boolean(),
+  isFriendRequestNotificationsEnabled: z.boolean(),
+  canShareArrivalStatus: z.boolean(),
+  fontFamily: CustomizeableFontFamilySchema,
+  userInterfaceStyle: UserInterfaceStyleSchema,
+  eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
+  eventCalendarDefaultLayout: EventCalendarLayoutSchema,
+  version: UserSettingsVersionSchema
+})
+
+/**
+ * A type representing a user's settings.
+ *
+ * Each instance of settings has a version number which is used for client
+ * and server side synchronization. When the client refreshes its settings,
+ * it compares its local version number with the version number of the server.
+ * If the server version number is higher than the client version number, then
+ * the client switches to using the server version number. If the client
+ * version number is higher than the server's, then the client sends its copy
+ * of the settings to the server.
+ */
+export type UserSettings = z.rInfer<typeof UserSettingsSchema>
+
+/**
+ * The default user settings which enables all fields, and sets the version
+ * number to zero.
+ */
+export const DEFAULT_USER_SETTINGS = {
+  isAnalyticsEnabled: true,
+  isCrashReportingEnabled: true,
+  isEventNotificationsEnabled: true,
+  isMentionsNotificationsEnabled: true,
+  isChatNotificationsEnabled: true,
+  isFriendRequestNotificationsEnabled: true,
+  canShareArrivalStatus: true,
+  fontFamily: "open-sans",
+  userInterfaceStyle: "system",
+  eventCalendarStartOfWeekDay: "monday",
+  eventCalendarDefaultLayout: "week-layout",
+  version: 0
+} satisfies Readonly<UserSettings>

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -14,34 +14,17 @@ export const EventCalendarWeekdaySchema = z.union([
   z.literal("saturday")
 ])
 
-export type EventCalendarWeekday = z.infer<typeof EventCalendarWeekdaySchema>
+export type EventCalendarWeekdayID = z.infer<typeof EventCalendarWeekdaySchema>
 
-export const EventCalendarLayoutSchema = z.union([
+export const EventCalendarLayoutIDSchema = z.union([
   z.literal("single-day-layout"),
   z.literal("week-layout"),
   z.literal("month-layout")
 ])
 
-export type EventCalendarLayout = z.infer<typeof EventCalendarLayoutSchema>
+export type EventCalendarLayoutID = z.infer<typeof EventCalendarLayoutIDSchema>
 
-export const UserInterfaceStyleSchema = z.union([
-  z.literal("light"),
-  z.literal("dark"),
-  z.literal("system")
-])
-
-export type UserInterfaceStyle = z.infer<typeof UserInterfaceStyleSchema>
-
-export const CustomizeableFontFamilySchema = z.union([
-  z.literal("open-sans"),
-  z.literal("open-dyslexic")
-])
-
-export type CustomizeableFontFamily = z.infer<
-  typeof CustomizeableFontFamilySchema
->
-
-export const EventChangeNotificationTriggerSchema = z.union([
+export const EventChangeNotificationTriggerIDSchema = z.union([
   z.literal("name-changed"),
   z.literal("description-changed"),
   z.literal("time-changed"),
@@ -64,11 +47,11 @@ export const EventChangeNotificationTriggerSchema = z.union([
  *
  * `"event-cancelled"` -> Triggers when the event is cancelled.
  */
-export type EventChangeNotificationTrigger = z.infer<
-  typeof EventChangeNotificationTriggerSchema
+export type EventChangeNotificationTriggerID = z.infer<
+  typeof EventChangeNotificationTriggerIDSchema
 >
 
-export const EventTimeNotificationTriggerSchema = z.union([
+export const EventTimeNotificationTriggerIDSchema = z.union([
   z.literal("before-event"),
   z.literal("event-started"),
   z.literal("event-ended")
@@ -84,11 +67,11 @@ export const EventTimeNotificationTriggerSchema = z.union([
  *
  * `"event-ended"` -> Triggers when the event ends.
  */
-export type EventTimeNotificationTrigger = z.infer<
-  typeof EventTimeNotificationTriggerSchema
+export type EventTimeNotificationTriggerID = z.infer<
+  typeof EventTimeNotificationTriggerIDSchema
 >
 
-export const FriendNotificationTriggerSchema = z.union([
+export const FriendNotificationTriggerSchemaID = z.union([
   z.literal("friend-request-received"),
   z.literal("friend-request-accepted")
 ])
@@ -103,11 +86,11 @@ export const FriendNotificationTriggerSchema = z.union([
  * `"friend-request-accepted"` -> Triggers when another user accpets the user's
  * friend request.
  */
-export type FriendNotificationTrigger = z.infer<
-  typeof FriendNotificationTriggerSchema
+export type FriendNotificationTriggerID = z.infer<
+  typeof FriendNotificationTriggerSchemaID
 >
 
-export const EventArrivalNotificationTriggerSchema = z.union([
+export const EventArrivalNotificationTriggerIDSchema = z.union([
   z.literal("user-entered-region"),
   z.literal("event-started"),
   z.literal("event-periodic-update")
@@ -125,20 +108,20 @@ export const EventArrivalNotificationTriggerSchema = z.union([
  * `"event-periodic-update"` -> Triggers at periodic intervals throughout the
  * duration of an event.
  */
-export type EventArrivalNotificationTrigger = z.infer<
-  typeof EventArrivalNotificationTriggerSchema
+export type EventArrivalNotificationTriggerID = z.infer<
+  typeof EventArrivalNotificationTriggerIDSchema
 >
 
 /**
  * A utility to toggle on or off an element in a setttings trigger set.
  */
-export const toggleSettingsTrigger = <Trigger extends string>(
-  triggers: Trigger[],
-  trigger: Trigger,
+export const toggleSettingsTriggerId = <TriggerID extends string>(
+  ids: TriggerID[],
+  id: TriggerID,
   isEnabled: boolean
 ) => {
-  const filteredTriggers = triggers.filter((t) => t !== trigger)
-  return isEnabled ? filteredTriggers.concat(trigger) : filteredTriggers
+  const filteredTriggers = ids.filter((t) => t !== id)
+  return isEnabled ? filteredTriggers.concat(id) : filteredTriggers
 }
 
 /**
@@ -151,19 +134,19 @@ export const UserSettingsSchema = z.object({
   isMentionsNotificationsEnabled: z.boolean(),
   isChatNotificationsEnabled: z.boolean(),
   isProfileNotificationsEnabled: z.boolean(),
-  eventArrivalNotificationTriggers: z.array(
-    EventArrivalNotificationTriggerSchema
+  eventArrivalNotificationTriggerIds: z.array(
+    EventArrivalNotificationTriggerIDSchema
   ),
-  eventChangeNotificationTriggers: z.array(
-    EventChangeNotificationTriggerSchema
+  eventChangeNotificationTriggerIds: z.array(
+    EventChangeNotificationTriggerIDSchema
   ),
-  eventTimeNotificationTriggers: z.array(EventTimeNotificationTriggerSchema),
-  friendNotificationTriggers: z.array(FriendNotificationTriggerSchema),
+  eventTimeNotificationTriggerIds: z.array(
+    EventTimeNotificationTriggerIDSchema
+  ),
+  friendNotificationTriggerIds: z.array(FriendNotificationTriggerSchemaID),
   canShareArrivalStatus: z.boolean(),
-  fontFamily: CustomizeableFontFamilySchema,
-  userInterfaceStyle: UserInterfaceStyleSchema,
   eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
-  eventCalendarDefaultLayout: EventCalendarLayoutSchema,
+  eventCalendarDefaultLayout: EventCalendarLayoutIDSchema,
   version: UserSettingsVersionSchema
 })
 
@@ -191,24 +174,22 @@ export const DEFAULT_USER_SETTINGS = {
   isMentionsNotificationsEnabled: true,
   isChatNotificationsEnabled: true,
   isProfileNotificationsEnabled: true,
-  eventChangeNotificationTriggers: [
+  eventChangeNotificationTriggerIds: [
     "time-changed",
     "event-cancelled",
     "location-changed"
   ],
-  eventArrivalNotificationTriggers: [
+  eventArrivalNotificationTriggerIds: [
     "event-started",
     "event-periodic-update",
     "user-entered-region"
   ],
-  eventTimeNotificationTriggers: ["before-event", "event-started"],
-  friendNotificationTriggers: [
+  eventTimeNotificationTriggerIds: ["before-event", "event-started"],
+  friendNotificationTriggerIds: [
     "friend-request-received",
     "friend-request-accepted"
   ],
   canShareArrivalStatus: true,
-  fontFamily: "open-sans",
-  userInterfaceStyle: "system",
   eventCalendarStartOfWeekDay: "monday",
   eventCalendarDefaultLayout: "week-layout",
   version: 0

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -4,7 +4,6 @@ import {
 } from "../lib/LinkifyIt"
 import { Match } from "linkify-it"
 import { z } from "zod"
-import { EventCalendarWeekdaySchema } from "./Event"
 
 export type UserID = string
 
@@ -99,53 +98,6 @@ export type UnblockedBidirectionalUserRelations = z.rInfer<
 export type BidirectionalUserRelations =
   | UnblockedBidirectionalUserRelations
   | BlockedBidirectionalUserRelations
-
-export const UserSettingsVersionSchema = z.number().nonnegative()
-
-export type UserSettingsVersion = z.infer<typeof UserSettingsVersionSchema>
-
-/**
- * A zod schema for {@link UserSettingsSchema}.
- */
-export const UserSettingsSchema = z.object({
-  isAnalyticsEnabled: z.boolean(),
-  isCrashReportingEnabled: z.boolean(),
-  isEventNotificationsEnabled: z.boolean(),
-  isMentionsNotificationsEnabled: z.boolean(),
-  isChatNotificationsEnabled: z.boolean(),
-  isFriendRequestNotificationsEnabled: z.boolean(),
-  canShareArrivalStatus: z.boolean(),
-  eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
-  version: UserSettingsVersionSchema
-})
-
-/**
- * A type representing a user's settings.
- *
- * Each instance of settings has a version number which is used for client
- * and server side synchronization. When the client refreshes its settings,
- * it compares its local version number with the version number of the server.
- * If the server version number is higher than the client version number, then
- * the client switches to using the server version number. If the client
- * version number is higher than the server's, then the client sends its copy
- * of the settings to the server.
- */
-export type UserSettings = z.rInfer<typeof UserSettingsSchema>
-
-/**
- * The default user settings which enables all fields, and sets the version
- * number to zero.
- */
-export const DEFAULT_USER_SETTINGS = {
-  isAnalyticsEnabled: true,
-  isCrashReportingEnabled: true,
-  isEventNotificationsEnabled: true,
-  isMentionsNotificationsEnabled: true,
-  isChatNotificationsEnabled: true,
-  isFriendRequestNotificationsEnabled: true,
-  canShareArrivalStatus: true,
-  version: 0
-} as Readonly<UserSettings>
 
 /**
  * An reason that a user handle's raw text was unable to be parsed.

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -4,6 +4,7 @@ import {
 } from "../lib/LinkifyIt"
 import { Match } from "linkify-it"
 import { z } from "zod"
+import { EventCalendarWeekdaySchema } from "./Event"
 
 export type UserID = string
 
@@ -114,6 +115,7 @@ export const UserSettingsSchema = z.object({
   isChatNotificationsEnabled: z.boolean(),
   isFriendRequestNotificationsEnabled: z.boolean(),
   canShareArrivalStatus: z.boolean(),
+  eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
   version: UserSettingsVersionSchema
 })
 


### PR DESCRIPTION
Moves the settings types into a `Settings.ts` file.

I also updated the notification settings to include "triggers". We could've easily done an `isXXXNotificationEnabled` property for each notification type, but that felt repetitive and possibly hard to read. Instead, I've made `XXXNotificationTrigger` types of typical string unions, and `UserSettings` can hold onto an array of those triggers. 

For now, there are 3 types of triggers based on our discussions:
1. Event information changes.
2. Event arrivals.
3. Friend requests.

Each one of those types of triggers is a string union with all the possible "trigger" values that can send a push notification to the user.

TASK_kJRwtAGS