### PR TITLE
Allow untracked PRs & Remove ticket id from the PR title when using "npm run pr"

### DIFF
--- a/.github/workflows/link-ticket-on-pull-request.yml
+++ b/.github/workflows/link-ticket-on-pull-request.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   link-ticket:
-    uses: tifapp/TiFShared/.github/workflows/link-ticket.yml@auto-ticket-link-and-pr
+    uses: tifapp/TiFShared/.github/workflows/link-ticket.yml@main
     secrets: inherit
     with:
       pullRequestCommentsUrl: ${{ github.event.pull_request.comments_url }}

--- a/.github/workflows/link-ticket.yml
+++ b/.github/workflows/link-ticket.yml
@@ -71,7 +71,17 @@ jobs:
     if: ${{ needs.capture-ticket-id.outputs.skip == 'false' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Check Untracked Task
+        run: |
+          if [[ "${{ needs.capture-ticket-id.outputs.ticket_id }}" == "UNTRACKED" ]]; then
+            echo "This is an untracked task, skipping job."
+            echo "UNTRACKED_TASK=true" >> $GITHUB_ENV
+          else
+            echo "UNTRACKED_TASK=false" >> $GITHUB_ENV
+          fi
+
       - name: Link PR and Trello Ticket
+        if: ${{ env.UNTRACKED_TASK != 'true' }}
         run: |
           TRELLO_TICKET_ID="${{ needs.capture-ticket-id.outputs.ticket_id }}"
           TRELLO_CARD_URL="https://trello.com/c/$TRELLO_TICKET_ID"

--- a/npm-scripts/auto-pr.ts
+++ b/npm-scripts/auto-pr.ts
@@ -35,7 +35,7 @@ const getPRDetails = async (ticketId?: string) => {
     }
     const data = await response.json() as {name: string, desc: string}
     log.info(`Using details of task "${data.name}" for pull request description.`)
-    return { prTitle: encodeURIComponent(`${ticketId} ${data.name}`), prBody: encodeURIComponent(
+    return { prTitle: encodeURIComponent(`${data.name}`), prBody: encodeURIComponent(
       `${data.desc}\n\nTicket ID: ${ticketId}`
     )}
   } catch (error) {


### PR DESCRIPTION
Changes:
* Allow for untracked PRs by adding "TASK_UNTRACKED" to the pr body or branch title. This will allow the ticket-link check to pass while not linking the PR to trello. Ideally all of our PRs should be linked to tickets, but in case we want to make minor PRs that arent linked to a ticket, this allows that to happen without resulting in a github action issue.
* When using "npm run pr", ticket id is removed from PR title since it's added to the PR body.
* Pointed ticket-link job to main branch in this repo



TASK_UNTRACKED