### PR TITLE
Shared API Schema + api test utils

### DIFF
--- a/api/APIValidation.test.ts
+++ b/api/APIValidation.test.ts
@@ -1,0 +1,178 @@
+import { z } from "zod"
+import { runMiddleware } from "../lib/Middleware"
+import { tryParseAPICall } from "./APIValidation"
+import { GenericEndpointSchema } from "./TransportTypes"
+
+const mockEndpointName = "MOCK_ENDPOINT"
+
+const apiValidator = ({endpointSchema, mockRequest, mockResponse}: {
+  endpointSchema: Omit<GenericEndpointSchema, "httpRequest">, 
+  mockRequest: any, 
+  mockResponse: any
+}) => 
+  runMiddleware(
+    tryParseAPICall(
+      mockEndpointName, 
+      endpointSchema as GenericEndpointSchema
+    ),
+    async () => mockResponse
+  )(mockRequest)
+
+describe("tryParseAPICall", () => {  
+  it("should throw an error if the request is invalid", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+          })
+        }
+      },
+      mockRequest: { query: { name: "John" } },
+      mockResponse: { status: 404, data: { message: "Not Found" } }
+    })
+
+    await expect(apiCall).rejects.toThrow(
+      `Making an invalid request to TiF API endpoint ${mockEndpointName}`
+    );
+  });
+
+  it("should throw an error if the response status is unexpected", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+          })
+        }
+      },
+      mockRequest: { body: { name: "John" } },
+      mockResponse: { status: 404, data: { message: "Not Found" } }
+    })
+
+    await expect(apiCall).rejects.toThrow(
+      `TiF API responded with an unexpected status code 404 and body {"message":"Not Found"}`
+    );
+  });
+  
+  it("should throw an error if response is not valid", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+          })
+        }
+      },
+      mockRequest: { body: { name: "John" } },
+      mockResponse: { status: 200, data: { name: 123 } }
+    })
+
+    await expect(apiCall).rejects.toThrow(
+      `TiF API endpoint ${mockEndpointName} responded with an invalid JSON body: {"name":123}`
+    );
+  });
+  
+  it("should throw an error if response does not match constraints", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+          })
+        },
+        constraints: (input: any, output: any) => { return input.body.name === output.data.name }
+      },
+      mockRequest: { body: { name: "John" } },
+      mockResponse: { status: 200, data: { name: "Johnny" } }
+    })
+
+    await expect(apiCall).rejects.toThrow(
+      `TiF API endpoint ${mockEndpointName} responded with an invalid JSON body: {"name":"Johnny"}`
+    );
+  });
+  
+  it("should return response if request and response are valid", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+          })
+        },
+        constraints: (input: any, output: any) => { return input.body.name === output.data.name }
+      },
+      mockRequest: { body: { name: "John" } },
+      mockResponse: { status: 200, data: { name: "John" } }
+    })
+
+    await expect(apiCall).resolves.toStrictEqual(
+      {"data": {"name": "John"}, "status": 200}
+    );
+  });
+  
+  it("should allow void inputs", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {},
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+          })
+        }
+      },
+      mockRequest: undefined,
+      mockResponse: { status: 200, data: { name: "John" } }
+    })
+
+    await expect(apiCall).resolves.toStrictEqual(
+      {"data": {"name": "John"}, "status": 200}
+    );
+  });
+  
+  it("should allow no content responses", async () => {
+    const apiCall = apiValidator({
+      endpointSchema: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status204: "no-content",
+        }
+      },
+      mockRequest: { body: { name: "John" } },
+      mockResponse: { status: 204, data: undefined }
+    })
+
+    await expect(apiCall).resolves.toStrictEqual(
+      {"data": undefined, "status": 204}
+    );
+  });
+});

--- a/api/APIValidation.ts
+++ b/api/APIValidation.ts
@@ -1,0 +1,45 @@
+import { ZodError, ZodObject, ZodTypeAny, z } from "zod";
+import { logger } from "../logging";
+import { EndpointSchemaToMiddleware } from "./TransportTypes";
+
+const log = logger("tif.api.validation")
+
+const zodValidation = async (data: any, schema: ZodObject<any>, errorMessage: string) => {
+    try {
+        return await schema.parseAsync(data) as any
+    } catch (e) {
+        if (e instanceof ZodError) {
+            log.trace("Zod Schema Error Message", {
+                zodError: JSON.parse(e.message)
+            })
+        }
+        throw new Error(`${errorMessage}: ${JSON.stringify(data)}`)
+    }
+}
+
+export const tryParseAPICall: EndpointSchemaToMiddleware = 
+  (endpointName, {input: inputSchema, outputs, constraints}) => 
+    async (input, next) => {
+      await zodValidation(input ?? {}, z.object(inputSchema), `Making an invalid request to TiF API endpoint ${endpointName}`)
+
+      const response = await next(input)
+
+      const responseSchema = outputs[`status${response.status}` as keyof typeof outputs] as ZodTypeAny | "no-content"
+
+      if (!responseSchema) {
+        throw new Error(
+          `TiF API responded with an unexpected status code ${response.status} and body ${JSON.stringify(response.data)}`
+        )
+      } else {
+        if (responseSchema !== "no-content") {
+          await zodValidation(
+            response.data, 
+            // GenericEndpointSchema does not have proper typing on constraints signature
+            //@ts-expect-error
+            responseSchema.refine(() => constraints ? constraints(input, response) : true), 
+            `TiF API endpoint ${endpointName} responded with an invalid JSON body`
+          )
+        }
+        return response
+      }
+    }

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,393 +1,44 @@
-import { UserHandleSchema, UserID, UserIDSchema } from "../domain-models/User"
-import {
-  EventAttendeesPageSchema,
-  EventRegion,
-  TrackableEventArrivalRegionsSchema
-} from "../domain-models/Event"
-import { z } from "zod"
-import { TiFAPIEndpoint, TiFAPITransport, tifAPITransport } from "./Transport"
-import {
-  UpdateCurrentUserProfileRequest,
-  UpdateUserSettingsRequest,
-  UserNotFoundResponseSchema,
-  UserSettingsResponseSchema,
-  userTiFAPIErrorSchema
-} from "./models/User"
-import { tifAPIErrorSchema } from "./models/Error"
-import {
-  EventNotFoundErrorSchema,
-  EventResponseSchema,
-  EventWhenBlockedByHostResponseSchema,
-  EventsInAreaResponseSchema,
-  JoinEventResponseSchema
-} from "./models/Event"
-import { LocationCoordinate2D } from "domain-models/LocationCoordinate2D"
-import { jwtMiddleware } from "./Middleware"
+import { TiFAPIClient, implementTiFAPI } from "./TiFAPISchema";
+import { tifAPITransport } from "./Transport";
+import { jwtMiddleware } from "./TransportMiddleware";
+import { MockAPIImplementation, mswBuilder } from "./mockAPIServer";
 
 export const TEST_API_URL = new URL("http://localhost:8080")
 
-type _StaticTiFAPI = typeof _TiFAPIClass
-export interface TiFAPIConstructor extends _StaticTiFAPI {}
-
-export interface TiFAPI extends InstanceType<TiFAPIConstructor> {}
-
-class _TiFAPIClass {
-  private readonly apiFetch: TiFAPITransport
-
-  constructor(apiFetch: TiFAPITransport) {
-    this.apiFetch = apiFetch
-  }
-
+export class TiFAPI {
   /**
-   * Creates the user's TiF profile after they have fully signed up and verified their account.
-   *
-   * @returns an object containing the user's id and generated user handle.
+   * An instance of {@link TiFAPIClient} for unit testing.
    */
-  async createCurrentUserProfile() {
-    return await this.apiFetch(
-      { method: "POST", endpoint: "/user" },
-      {
-        status201: z.object({
-          id: UserIDSchema,
-          handle: UserHandleSchema
-        })
-      }
-    )
-  }
-
-  /**
-   * Updates the current user's profile attributes.
-   */
-  async updateCurrentUserProfile(request: UpdateCurrentUserProfileRequest) {
-    return await this.apiFetch(
-      {
-        method: "PATCH",
-        endpoint: "/user/self",
-        body: request
-      },
-      {
-        status204: "no-content"
-      }
-    )
-  }
-
-  /**
-   * Given a partial handle, returns a list of autocompleted users with a similar handle.
-   *
-   * @param handle a handle string.
-   * @param limit the maximum amount of users to return.
-   * @param signal an {@link AbortSignal} to cancel the query.
-   * @returns an object with a list of users containing their name, handle, and id.
-   */
-  async autocompleteUsers(handle: string, limit: number, signal?: AbortSignal) {
-    return await this.apiFetch(
-      {
-        method: "GET",
-        endpoint: "/user/autocomplete",
-        query: { handle, limit }
-      },
-      {
-        status200: z.object({
-          users: z.array(
-            z.object({
-              id: UserIDSchema,
-              name: z.string(),
-              handle: UserHandleSchema
-            })
-          )
-        })
-      },
-      signal
-    )
-  }
-
-  /**
-   * Indicates that the user has arrived at the given region.
-   *
-   * @returns a list of regions of the user's upcoming events.
-   */
-  async arriveAtRegion(region: EventRegion) {
-    return await this.apiFetch(
-      {
-        method: "POST",
-        endpoint: "/event/arrived",
-        body: region
-      },
-      {
-        status200: TrackableEventArrivalRegionsSchema
-      }
-    )
-  }
-
-  /**
-   * Indicates that the user has departed from the given region.
-   *
-   * @returns a list of regions of the user's upcoming events.
-   */
-  async departFromRegion(region: EventRegion) {
-    return await this.apiFetch(
-      {
-        method: "POST",
-        endpoint: "/event/departed",
-        body: region
-      },
-      {
-        status200: TrackableEventArrivalRegionsSchema
-      }
-    )
-  }
-
-  /**
-   * Fetches all upcoming event arrival regions.
-   *
-   * The regions include ids of events that are either ongoing, or
-   * start within the next 24 hours.
-   *
-   * @returns a list of regions of the user's upcoming events.
-   */
-  async upcomingEventArrivalRegions() {
-    return await this.apiFetch(
-      {
-        method: "GET",
-        endpoint: "/event/upcoming"
-      },
-      { status200: TrackableEventArrivalRegionsSchema }
-    )
-  }
-
-  /**
-   * Loads an individual event by its id.
-   */
-  async eventDetails(eventId: number) {
-    return await this.apiFetch(
-      {
-        method: "GET",
-        endpoint: `/event/details/${eventId}`
-      },
-      {
-        status200: EventResponseSchema.refine((resp) => resp.id === eventId),
-        status204: "no-content",
-        status404: EventNotFoundErrorSchema,
-        status403: EventWhenBlockedByHostResponseSchema.refine(
-          (resp) => resp.id === eventId
-        )
-      }
-    )
-  }
-
-  async attendeesList(eventId: number, limit: number, nextPage?: string) {
-    return await this.apiFetch(
-      {
-        method: "GET",
-        endpoint: `/event/attendees/${eventId}`,
-        query: { limit, nextPage }
-      },
-      {
-        status200: EventAttendeesPageSchema,
-        status204: "no-content",
-        status404: EventNotFoundErrorSchema,
-        status403: tifAPIErrorSchema("blocked-by-host")
-      }
-    )
-  }
-
-  /**
-   * Joins the event with the given id.
-   *
-   * @param eventId The id of the event to join.
-   * @param arrivalRegion A region to pass for marking an initial arrival if the user has arrived in the area of the event.
-   * @returns The upcoming event arrivals based on the user joining this event, and a token request for the event group chat.
-   */
-  async joinEvent(eventId: number, arrivalRegion: EventRegion | null) {
-    const body = arrivalRegion ? { region: arrivalRegion } : undefined
-    return await this.apiFetch(
-      {
-        method: "POST",
-        endpoint: `/event/join/${eventId}`,
-        body
-      },
-      {
-        status403: tifAPIErrorSchema(
-          "event-has-ended",
-          "event-was-cancelled",
-          "user-is-blocked"
-        ),
-        status201: JoinEventResponseSchema.refine(
-          (resp) => resp.id === eventId
-        ),
-        status200: JoinEventResponseSchema.refine((resp) => resp.id === eventId)
-      }
-    )
-  }
-
-  /**
-   * Leaves the event with the given id.
-   *
-   * @param eventId The id of the event to leave.
-   */
-  async leaveEvent(eventId: number) {
-    return await this.apiFetch(
-      {
-        method: "POST",
-        endpoint: `/event/leave/${eventId}`
-      },
-      {
-        status403: tifAPIErrorSchema(
-          "event-has-been-cancelled",
-          "event-has-ended"
-        ),
-        status400: tifAPIErrorSchema("co-host-not-found", "already-left-event"),
-        status204: "no-content"
-      }
-    )
-  }
-
-  /**
-   * Registers for the user for push notifications given a push token and a
-   * platform name.
-   */
-  async registerForPushNotifications(
-    pushToken: string,
-    platformName: "apple" | "android"
-  ) {
-    return await this.apiFetch(
-      {
-        method: "POST",
-        endpoint: "/user/notifications/push/register",
-        body: { pushToken, platformName }
-      },
-      {
-        status201: z.object({ status: z.literal("inserted") }),
-        status400: tifAPIErrorSchema("token-already-registered")
-      }
-    )
-  }
-
-  /**
-   * Blocks a user.
-   *
-   * Blocks can be mutual (ie. 2 users can block each other regardless of if
-   * they have been blocked by the user they are trying to block), so this
-   * endpoint only fails if the given user id does not exist.
-   */
-  async blockUser(id: UserID) {
-    return await this.apiFetch(
-      {
-        method: "PATCH",
-        endpoint: `/user/block/${id}`
-      },
-      {
-        status204: "no-content",
-        status404: UserNotFoundResponseSchema
-      }
-    )
-  }
-
-  /**
-   * Unblocks a user.
-   *
-   * Blocks can be mutual (ie. 2 users can block each other regardless of if
-   * they have been blocked by the user they are trying to block), so this
-   * endpoint only fails if the given user id does not exist or if the user
-   * is not blocked in the first place.
-   */
-  async unblockUser(id: UserID) {
-    return await this.apiFetch(
-      {
-        method: "DELETE",
-        endpoint: `/user/block/${id}`
-      },
-      {
-        status204: "no-content",
-        status404: UserNotFoundResponseSchema,
-        status403: userTiFAPIErrorSchema("user-not-blocked")
-      }
-    )
-  }
-
-  /**
-   * Returns the events in the area of the center with the given radius in
-   * meters.
-   */
-  async exploreEvents(
-    center: LocationCoordinate2D,
-    radiusMeters: number,
-    signal?: AbortSignal
-  ) {
-    return await this.apiFetch(
-      {
-        method: "POST",
-        endpoint: "/event/region",
-        body: {
-          userLatitude: center.latitude,
-          userLongitude: center.longitude,
-          radius: radiusMeters
-        }
-      },
-      { status200: EventsInAreaResponseSchema },
-      signal
-    )
-  }
-
-  /**
-   * Returns the remote settings for the current user.
-   */
-  async userSettings() {
-    return await this.apiFetch(
-      {
-        method: "GET",
-        endpoint: "/user/self/settings"
-      },
-      { status200: UserSettingsResponseSchema }
-    )
-  }
-
-  /**
-   * Saves the specified user settings and returns the updated user settings.
-   */
-  async saveUserSettings(request: UpdateUserSettingsRequest) {
-    return await this.apiFetch(
-      {
-        method: "PATCH",
-        endpoint: "/user/self/settings",
-        body: request
-      },
-      { status200: UserSettingsResponseSchema }
-    )
-  }
-}
-
-/**
- * A high-level client for the TiF API.
- *
- * This class provides wrapper functions which use the lower level
- * {@link TiFAPITransport} function. Function parameters and return values in
- * this class represent honest data from the API, and not the exact data that
- * the UI may need. Therefore, this class should not be used directly in a UI
- * or frontend layer (eg. react), and should instead be used inside a data
- * layer that the UI can call into.
- */
-export const TiFAPI = _TiFAPIClass as TiFAPIConstructor
-
-export interface TiFAPIConstructor {
-  /**
-   * A {@link TiFAPI} instance to use for unit testing.
-   */
-  testAuthenticatedInstance: TiFAPI
-
-  /**
-   * Creates a test URL string that can be used with MSW.
-   */
-  testPath(endpoint: TiFAPIEndpoint): string
-}
-
-TiFAPI.testAuthenticatedInstance = new TiFAPI(
-  tifAPITransport(
-    TEST_API_URL,
-    jwtMiddleware(
-      async () => "I was here at the beginning, and I will proclaim the end."
+  static testAuthenticatedInstance = implementTiFAPI(
+    tifAPITransport(
+      TEST_API_URL,
+      jwtMiddleware(
+        async () => "I was here at the beginning, and I will proclaim the end."
+      )
     )
   )
-)
 
-TiFAPI.testPath = (endpoint) => `${TEST_API_URL}${endpoint.slice(1)}`
+  /**
+   * An instance of {@link TiFAPIClient} for unit testing.
+   */
+  static testUnauthenticatedInstance = implementTiFAPI(
+    tifAPITransport(
+      TEST_API_URL,
+      async (request, next) => next(request)
+    )
+  )
+  
+  /**
+   * Mocks an api server for unit testing.
+   */
+  static mockServer = (
+    endpointMocks: Partial<{
+      [EndpointName in keyof TiFAPIClient]: MockAPIImplementation<TiFAPIClient[EndpointName]>
+    }>
+  ) =>
+    implementTiFAPI(
+      undefined,
+      undefined,
+      (endpointName, { httpRequest: { method, endpoint }}) => mswBuilder(TEST_API_URL, method, endpoint, endpointMocks[endpointName as keyof TiFAPIClient] as any)
+    );
+}

--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -1,0 +1,416 @@
+import { z } from "zod";
+import { EventAttendeesPageSchema, EventIDSchema, EventRegionSchema, TrackableEventArrivalRegionsSchema } from "../domain-models/Event";
+import { LocationCoordinate2DSchema } from "../domain-models/LocationCoordinate2D";
+import { UserHandleSchema, UserIDSchema } from "../domain-models/User";
+import { MatchFnCollection } from "../lib/Types/MatchType";
+import { EndpointSchemaToMiddleware, EndpointSchemasToFunctions, assertEndpointSchemaType } from "./TransportTypes";
+import { APIImplementationCollector, implementAPI } from "./implementAPI";
+import { tifAPIErrorSchema } from "./models/Error";
+import { EventNotFoundErrorSchema, EventResponseSchema, EventWhenBlockedByHostResponseSchema, EventsInAreaResponseSchema, JoinEventResponseSchema } from "./models/Event";
+import { UpdateCurrentUserProfileRequestSchema, UpdateUserSettingsRequestSchema, UserNotFoundResponseSchema, UserSettingsResponseSchema, userTiFAPIErrorSchema } from "./models/User";
+
+const TiFAPISchema = {
+  /**
+   * Creates the user's TiF profile after they have fully signed up and verified their account.
+   *
+   * @returns an object containing the user's id and generated user handle.
+   */
+  createCurrentUserProfile: assertEndpointSchemaType({
+    input: {},
+    outputs: {
+      status201: z.object({
+        id: UserIDSchema,
+        handle: UserHandleSchema
+      })
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: "/user"
+    }
+  }),
+
+  /**
+   * Updates the current user's profile attributes.
+   */
+  updateCurrentUserProfile: assertEndpointSchemaType({
+    input: {
+      body: UpdateCurrentUserProfileRequestSchema
+    },
+    outputs: {
+      status204: "no-content",
+    },
+    httpRequest: {
+      method: "PATCH",
+      endpoint: "/user/self",
+    },
+  }),
+
+  /**
+   * Given a partial handle, returns a list of autocompleted users with a similar handle.
+   *
+   * @param handle a handle string.
+   * @param limit the maximum amount of users to return.
+   * @param signal an {@link AbortSignal} to cancel the query.
+   * @returns an object with a list of users containing their name, handle, and id.
+   */
+  autocompleteUsers: assertEndpointSchemaType({
+    input: {
+      query: z.object({
+        handle: z.string(), 
+        limit: z.number()
+      })
+    },
+    outputs: {
+      status200: z.object({
+        users: z.array(
+          z.object({
+            id: UserIDSchema,
+            name: z.string(),
+            handle: UserHandleSchema
+          })
+        )
+      })
+    },
+    httpRequest: {
+      method: "GET",
+      endpoint: "/user/autocomplete",
+    }
+  }),
+  
+  /**
+   * Indicates that the user has arrived at the given region.
+   *
+   * @returns a list of regions of the user's upcoming events.
+   */
+  arriveAtRegion: assertEndpointSchemaType({
+    input: {
+      body: EventRegionSchema
+    },
+    outputs: {
+      status200: TrackableEventArrivalRegionsSchema
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: "/event/arrived",
+    }
+  }),
+  
+  /**
+   * Indicates that the user has departed from the given region.
+   *
+   * @returns a list of regions of the user's upcoming events.
+   */
+  departFromRegion: assertEndpointSchemaType({
+    input: {
+      body: EventRegionSchema
+    },
+    outputs: {
+      status200: TrackableEventArrivalRegionsSchema
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: "/event/departed",
+    }
+  }),
+  
+  /**
+   * Fetches all upcoming event arrival regions.
+   *
+   * The regions include ids of events that are either ongoing, or
+   * start within the next 24 hours.
+   *
+   * @returns a list of regions of the user's upcoming events.
+   */
+  upcomingEventArrivalRegions: assertEndpointSchemaType({
+    input: {},
+    outputs: {
+      status200: TrackableEventArrivalRegionsSchema
+    },
+    httpRequest: {
+      method: "GET",
+      endpoint: "/event/upcoming"
+    }
+  }),
+
+  /**
+   * Loads an individual event by its id.
+   */
+  eventDetails: assertEndpointSchemaType({
+    input: {
+      params: z.object({
+        eventId: EventIDSchema
+      })
+    },
+    outputs: {
+      status200: EventResponseSchema,
+      status204: "no-content",
+      status404: EventNotFoundErrorSchema,
+      status403: EventWhenBlockedByHostResponseSchema
+    },
+    constraints: (input, output) => {
+      if (output.status === 200 || output.status === 403) {
+        return output.data.id === input.params.eventId
+      }
+
+      return true;
+    },
+    httpRequest: {
+      method: "GET",
+      endpoint: `/event/details/:eventId`
+    },
+  }),
+  
+  /**
+   * Fetches a paginated list of attendees for a given event.
+   * 
+   * @param eventId The id of the event to check.
+   * @param limit the maximum amount of users to return.
+   * @param nextPage points to a particular section in the attendees list
+   */
+  attendeesList: assertEndpointSchemaType({
+    input: {
+      params: z.object({
+        eventId: EventIDSchema
+      }),
+      query: z.object({
+        limit: z.number(),
+        nextPage: z.string().optional()
+      }),
+    },
+    outputs: {
+      status200: EventAttendeesPageSchema,
+      status204: "no-content",
+      status404: EventNotFoundErrorSchema,
+      status403: tifAPIErrorSchema("blocked-by-host")
+    },
+    httpRequest: {
+      method: "GET",
+      endpoint: `/event/attendees/:eventId`,
+    },
+  }),
+  
+  /**
+   * Joins the event with the given id.
+   *
+   * @param eventId The id of the event to join.
+   * @param arrivalRegion A region to pass for marking an initial arrival if the user has arrived in the area of the event.
+   * @returns The upcoming event arrivals based on the user joining this event, and a token request for the event group chat.
+   */
+  joinEvent: assertEndpointSchemaType({
+    input: {
+      params: z.object({
+        eventId: EventIDSchema
+      }),
+      body: z.object({
+        region: EventRegionSchema
+      }).optional(),
+    },
+    outputs: {
+      status403: tifAPIErrorSchema(
+        "event-has-ended",
+        "event-was-cancelled",
+        "user-is-blocked"
+      ),
+      status201: JoinEventResponseSchema,
+      status200: JoinEventResponseSchema
+    },
+    constraints: (input, output) => {
+      if (output.status === 200 || output.status === 201) {
+        return output.data.id === input.params.eventId
+      }
+
+      return true;
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: `/event/join/:eventId`,
+    },
+  }),
+  
+  /**
+   * Leaves the event with the given id.
+   *
+   * @param eventId The id of the event to leave.
+   */
+  leaveEvent: assertEndpointSchemaType({
+    input: {
+      params: z.object({
+        eventId: EventIDSchema
+      }),
+    },
+    outputs: {
+      status403: tifAPIErrorSchema(
+        "event-has-been-cancelled",
+        "event-has-ended"
+      ),
+      status400: tifAPIErrorSchema("co-host-not-found", "already-left-event"),
+      status204: "no-content"
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: `/event/leave/:eventId`
+    },
+  }),
+
+  /**
+   * Registers for the user for push notifications given a push token and a
+   * platform name.
+   */
+  registerForPushNotifications: assertEndpointSchemaType({
+    input: {
+      body: z.object({
+        pushToken: z.string(),
+        platformName: z.literal("apple").or(z.literal("android"))
+      })
+    },
+    outputs: {
+      status201: z.object({ status: z.literal("inserted") }),
+      status400: tifAPIErrorSchema("token-already-registered")
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: "/user/notifications/push/register",
+    }
+  }),
+  
+  /**
+   * Blocks a user.
+   *
+   * Blocks can be mutual (ie. 2 users can block each other regardless of if
+   * they have been blocked by the user they are trying to block), so this
+   * endpoint only fails if the given user id does not exist.
+   */
+  blockUser: assertEndpointSchemaType({
+    input: {
+      params: z.object({
+        id: UserIDSchema
+      })
+    },
+    outputs: {
+      status204: "no-content",
+      status404: UserNotFoundResponseSchema
+    },
+    httpRequest: {
+      method: "PATCH",
+      endpoint: `/user/block/:id`
+    }
+  }),
+  
+  /**
+   * Unblocks a user.
+   *
+   * Blocks can be mutual (ie. 2 users can block each other regardless of if
+   * they have been blocked by the user they are trying to block), so this
+   * endpoint only fails if the given user id does not exist or if the user
+   * is not blocked in the first place.
+   */
+  unblockUser: assertEndpointSchemaType({
+    input: {
+      params: z.object({
+        id: UserIDSchema
+      })
+    },
+    outputs: {
+      status204: "no-content",
+      status404: UserNotFoundResponseSchema,
+      status403: userTiFAPIErrorSchema("user-not-blocked")
+    },
+    httpRequest: {
+      method: "DELETE",
+      endpoint: `/user/block/:id`
+    },
+  }),
+
+  /**
+   * Returns the events in the area of the center with the given radius in
+   * meters.
+   */
+  exploreEvents: assertEndpointSchemaType({
+    input: {
+      body: z.object({
+        userLocation: LocationCoordinate2DSchema,
+        radius: z.number()
+      })
+    },
+    outputs: {
+      status200: EventsInAreaResponseSchema 
+    },
+    httpRequest: {
+      method: "POST",
+      endpoint: "/event/region",
+    },
+  }),
+
+  /**
+   * Returns the remote settings for the current user.
+   */
+  userSettings: assertEndpointSchemaType({
+    input: {},
+    outputs: { 
+      status200: UserSettingsResponseSchema 
+    },
+    httpRequest: {
+      method: "GET",
+      endpoint: "/user/self/settings"
+    },
+  }),
+  
+  /**
+   * Saves the specified user settings and returns the updated user settings.
+   */
+  saveUserSettings: assertEndpointSchemaType({
+    input: {
+      body: UpdateUserSettingsRequestSchema
+    },
+    outputs: { 
+      status200: UserSettingsResponseSchema 
+    },
+    httpRequest: {
+      method: "PATCH",
+      endpoint: "/user/self/settings",
+    },
+  }),
+}
+
+export type TiFAPIClient = EndpointSchemasToFunctions<typeof TiFAPISchema>
+
+/**
+ * Implement the functions described in the endpoint schema, given TiFAPIMiddleware or direct implementation functions. 
+ *
+ * ```ts
+ * const EndpointSchema = {
+ *  createCurrentUserProfile: assertEndpointSchemaType({
+ *    input: {},
+ *      outputs: {
+ *         status201: z.object({
+ *            id: z.string(),
+ *          })
+ *      },
+ *      httpRequest: {
+ *        method: "POST",
+ *        endpoint: "/user"
+ *      }
+ *  }),
+ * }
+ *
+ * const api = await implementTiFAPI(
+ *  (endpointName, { httpRequest: { endpoint, method } }) => 
+ *    async ({ body } = {}) =>
+ *      fetchFunction(endpoint, method, body),
+ * )
+ *
+ * const response = await api.createCurrentUserProfile()
+ * //response is inferred to be {status: 201, data: {id: string}}
+ * ```
+ */
+export const implementTiFAPI = <Fns extends TiFAPIClient>(
+  endpointSchemaToMiddleware?: EndpointSchemaToMiddleware, 
+  implementations?: MatchFnCollection<TiFAPIClient, Fns>,
+  implementationCollector?: APIImplementationCollector
+): TiFAPIClient => 
+  implementAPI(
+    TiFAPISchema,
+    endpointSchemaToMiddleware, 
+    implementations, 
+    implementationCollector
+  )

--- a/api/Transport.test.ts
+++ b/api/Transport.test.ts
@@ -1,120 +1,76 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { HttpResponse, http } from "msw"
-import { z } from "zod"
+import { URLEndpoint } from "../lib/URL"
 import { addLogHandler, consoleLogHandler, resetLogHandlers } from "../logging"
 import { mswServer, noContentResponse } from "../test-helpers/MSW"
 import { tifAPITransport } from "./Transport"
-import { jwtMiddleware } from "./TransportMiddleware"
+import { TiFAPITransportMiddleware, jwtMiddleware } from "./TransportMiddleware"
+import { APIHandler, GenericEndpointSchema, HTTPMethod } from "./TransportTypes"
 
-const TEST_BASE_URL = new URL("http://localhost:8080")
+const TEST_BASE_URL = "http://localhost:8080"
+const TEST_ENDPOINT = "/test"
 
 const TEST_JWT = "this is a totally a JWT"
 
-const apiFetch = tifAPITransport(
-  TEST_BASE_URL,
-  jwtMiddleware(async () => TEST_JWT)
-)
+const apiFetch = (method: HTTPMethod, endpoint?: URLEndpoint, middleware?: TiFAPITransportMiddleware) => 
+  tifAPITransport(
+    new URL(TEST_BASE_URL),
+    middleware ?? jwtMiddleware(async () => TEST_JWT)
+  )(
+    "_", 
+    ({httpRequest: {method, endpoint: endpoint ?? TEST_ENDPOINT}} as GenericEndpointSchema)
+  ) as APIHandler
 
 const successResponse = () => HttpResponse.json({ a: 1 })
 
-const badResponse = (status: number) => {
-  return HttpResponse.json({ b: "bad" }, { status })
-}
-
-const TestResponseSchema = {
-  status400: z.object({ b: z.string() }),
-  status200: z.object({ a: z.number() })
-}
-
 describe("TiFAPITransport tests", () => {
-  beforeEach(() => {
-    mswServer.use(
-      http.post("http://localhost:8080/test", async ({ request }) => {
-        // TODO: Use helper method for creating httpresponses
-        // https://mswjs.io/docs/migrations/1.x-to-2.x#response-declaration
-        const errorResp = badResponse(400) as any
-        const body: any = await request.json()
-        const searchParams = new URL(request.url).searchParams
-
-        if (request.headers.get("Authorization") !== `Bearer ${TEST_JWT}`) {
-          return errorResp
-        }
-        if (
-          searchParams.get("hello") !== "world" ||
-          searchParams.get("a") !== "1"
-        ) {
-          return errorResp
-        }
-
-        if (body?.a !== 1 || body?.b !== "hello") {
-          return errorResp
-        }
-        return successResponse()
-      }),
-      http.get("http://localhost:8080/test2", async ({ request }) => {
-        try {
-          await request.json()
-          return badResponse(400) as any
-        } catch {
-          return successResponse()
-        }
-      }),
-      http.get("http://localhost:8080/test3", async () => {
-        return badResponse(500)
-      }),
-      http.get("http://localhost:8080/test4", async () => {
-        return new HttpResponse("LMAO", { status: 200 })
-      }),
-      http.get("http://localhost:8080/test5", async () => {
-        return badResponse(200)
-      }),
-      http.get("http://localhost:8080/test6", async () => {
-        return noContentResponse()
-      }),
-      http.get("http://localhost:8080/test7", async () => {
-        await new Promise<void>(() => {})
-        return new HttpResponse(null, { status: 500 })
-      }),
-      http.get("http://localhost:8080/test8", async ({ request }) => {
-        if (new URLSearchParams(request.url).has("hello")) {
-          return new HttpResponse(null, { status: 500 })
-        }
-        return successResponse()
-      }),
-      http.get("http://localhost:8080/test9", async () => {
-        return HttpResponse.json({ hello: "world" }, { status: 204 })
-      })
-    )
-  })
-
   beforeAll(() => addLogHandler(consoleLogHandler()))
   afterAll(() => resetLogHandlers())
 
   test("api client fetch", async () => {
-    const resp = await apiFetch(
-      {
-        method: "POST",
-        endpoint: "/test",
-        query: { hello: "world", a: 1 },
-        body: { a: 1, b: "hello" }
-      },
-      TestResponseSchema
+    mswServer.use(
+      http.post(`${TEST_BASE_URL}${TEST_ENDPOINT}/:id`, async ({ request, params }) => {
+        const body: any = await request.json()
+        const searchParams = new URL(request.url).searchParams
+
+        expect(request.headers.get("Authorization")).toBe(`Bearer ${TEST_JWT}`)
+        expect(request.headers.get("Content-Type")).toBe("application/json")
+        expect(params.id).toBe("abc")
+        expect(searchParams.get("hello")).toBe("world")
+        expect(searchParams.get("a")).toBe("1")
+        expect(body?.a).toBe(1)
+        expect(body?.b).toBe("hello")
+
+        return successResponse()
+      })
     )
 
+    const resp = await apiFetch("POST", `${TEST_ENDPOINT}/:id`)({
+      params: { id: "abc" },
+      query: { hello: "world", a: 1 },
+      body: { a: 1, b: "hello" }
+    })
+
     expect(resp).toMatchObject({
-      status: 200,
+      status: 200,  
       data: { a: 1 }
     })
   })
 
   test("api client fetch, undefined query", async () => {
-    const resp = await apiFetch(
+    mswServer.use(
+      http.get(`${TEST_BASE_URL}${TEST_ENDPOINT}`, async ({ request }) => {
+        if (new URLSearchParams(request.url).has("hello")) {
+          return new HttpResponse(null, { status: 500 })
+        }
+        return successResponse()
+      })
+    )
+
+    const resp = await apiFetch("GET")(
       {
-        method: "GET",
-        endpoint: "/test8",
         query: { hello: undefined }
-      },
-      TestResponseSchema
+      }
     )
 
     expect(resp).toMatchObject({
@@ -124,13 +80,15 @@ describe("TiFAPITransport tests", () => {
   })
 
   test("api client fetch, no body", async () => {
-    const resp = await apiFetch(
-      {
-        method: "GET",
-        endpoint: "/test2"
-      },
-      TestResponseSchema
+    mswServer.use(
+      http.get(`${TEST_BASE_URL}${TEST_ENDPOINT}`, async ({ request }) => {
+        expect(async () => request.json()).rejects.toThrow()
+
+        return successResponse()
+      })
     )
+
+    const resp = await apiFetch("GET")()
 
     expect(resp).toMatchObject({
       status: 200,
@@ -138,89 +96,39 @@ describe("TiFAPITransport tests", () => {
     })
   })
 
-  test("api client fetch, response code not in schema", async () => {
-    await expect(
-      apiFetch(
-        {
-          method: "GET",
-          endpoint: "/test3"
-        },
-        TestResponseSchema
-      )
-    ).rejects.toEqual(
-      new Error(
-        'TiF API responded with an unexpected status code 500 and body {"b":"bad"}'
-      )
-    )
-  })
-
   test("api client fetch, json not returned from API", async () => {
-    await expect(
-      apiFetch(
-        {
-          method: "GET",
-          endpoint: "/test4"
-        },
-        TestResponseSchema
-      )
-    ).rejects.toEqual(
+    mswServer.use(
+      http.get(`${TEST_BASE_URL}${TEST_ENDPOINT}`, async () => {
+        return new HttpResponse("LMAO", { status: 200 })
+      })
+    )
+
+    await expect(apiFetch("GET")()).rejects.toEqual(
       new Error("TiF API responded with non-JSON body and status 200.")
     )
   })
 
-  test("api client fetch, invalid json returned from API", async () => {
-    await expect(
-      apiFetch(
-        {
-          method: "GET",
-          endpoint: "/test5"
-        },
-        TestResponseSchema
-      )
-    ).rejects.toEqual(
-      new Error(
-        'TiF API responded with an invalid JSON body {"b":"bad"} and status 200.'
-      )
-    )
-  })
-
-  test("api client fetch, empty body on 204, response schema doesn't list a 204 response", async () => {
-    await expect(
-      apiFetch(
-        {
-          method: "GET",
-          endpoint: "/test6"
-        },
-        TestResponseSchema
-      )
-    ).rejects.toEqual(
-      new Error(
-        'TiF API responded with an unexpected status code 204 and body ""'
-      )
-    )
-  })
-
-  test("api client fetch, empty body on 204, response schema lists a 204 response", async () => {
-    const resp = await apiFetch(
-      {
-        method: "GET",
-        endpoint: "/test6"
-      },
-      { ...TestResponseSchema, status204: "no-content" }
+  test("api client fetch, empty body on 204", async () => {
+    mswServer.use(
+      http.get(`${TEST_BASE_URL}${TEST_ENDPOINT}`, async () => {
+        return noContentResponse()
+      })
     )
 
-    expect(resp.data).toMatchObject({})
+    const resp = await apiFetch("GET")()
+
+    expect(resp.data).toEqual(undefined)
   })
 
-  test("api client fetch, non-empty body on 204, response schema lists a 204 response", async () => {
+  test("api client fetch, non-empty body on 204", async () => {
+    mswServer.use(
+      http.get(`${TEST_BASE_URL}${TEST_ENDPOINT}`, async () => {
+        return HttpResponse.json({ hello: "world" }, { status: 204 })
+      })
+    )
+
     await expect(
-      apiFetch(
-        {
-          method: "GET",
-          endpoint: "/test9"
-        },
-        { ...TestResponseSchema, status204: "no-content" }
-      )
+      apiFetch("GET")()
     ).rejects.toEqual(
       new Error(
         'TiFAPI responded with a 204 status code and body {"hello":"world"}. A 204 status code should not produce a body.'
@@ -228,39 +136,39 @@ describe("TiFAPITransport tests", () => {
     )
   })
 
-  test("cancellation", async () => {
-    const controller = new AbortController()
-    const respPromise = apiFetch(
+  test("logs error", async () => {
+    const logHandler = jest.fn()
+    addLogHandler(logHandler)
+    const respPromise = apiFetch("GET", undefined, () => { throw new Error("Fetch error") })()
+
+    await expect(respPromise).rejects.toThrow("Fetch error")
+    expect(logHandler).toHaveBeenCalledWith("tif.api.client", 
+      "error", 
+      "Failed to make tif API request.", 
       {
-        method: "GET",
-        endpoint: "/test7"
-      },
-      TestResponseSchema,
-      controller.signal
+        "endpointName": "_", 
+        "error": new Error("Fetch error"), 
+        "errorMessage": "Fetch error", 
+        "input": {"body": undefined, "params": undefined, "query": undefined}
+      }
     )
-
-    process.nextTick(() => controller.abort())
-
-    await expect(respPromise).rejects.toThrow(
-      new DOMException("This operation was aborted")
-    )
+    resetLogHandlers()
   })
 
   test("cancellation, does not log error", async () => {
+    mswServer.use(
+      http.get(`${TEST_BASE_URL}${TEST_ENDPOINT}`, async () => {
+        await new Promise<void>(() => {})
+      }),
+    )
+
     const logHandler = jest.fn()
     addLogHandler(logHandler)
     const controller = new AbortController()
-    const respPromise = apiFetch(
-      {
-        method: "GET",
-        endpoint: "/test7"
-      },
-      TestResponseSchema,
-      controller.signal
-    )
+    const respPromise = apiFetch("GET")({signal: controller.signal})
 
     process.nextTick(() => controller.abort())
-    await expect(respPromise).rejects.toThrow()
+    await expect(respPromise).rejects.toThrow("This operation was aborted")
     expect(logHandler).not.toHaveBeenCalled()
     resetLogHandlers()
   })

--- a/api/Transport.ts
+++ b/api/Transport.ts
@@ -1,238 +1,88 @@
-import { ZodError, ZodSchema, ZodType, z } from "zod"
-import { ToStringable } from "../lib/String"
-import { JSONSerializableValue, Reassign } from "../lib/Types/HelperTypes"
+
+import { urlString } from "../lib/URL"
 import { logger } from "../logging"
 import { TiFAPITransportMiddleware } from "./TransportMiddleware"
+import { APIRequestBody, EndpointSchemaToMiddleware, HTTPMethod, StatusCodeMap } from "./TransportTypes"
 
-export type TiFHTTPMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
-
-export type TiFAPIRequestQueryParameters = {
-  [key: string]: ToStringable | undefined
-}
-
-export type TiFAPINoContentSchema = "no-content"
-
-export type TiFAPIEndpoint = `/${string}`
-
-export type BaseTiFAPIRequest<Method extends TiFHTTPMethod> = {
-  method: Method
-  endpoint: TiFAPIEndpoint
-  body?: { [key: string]: JSONSerializableValue }
-  query?: TiFAPIRequestQueryParameters
-}
-
-/**
- * A type defining an API request to the backend.
- */
-export type TiFAPIRequest<Method extends TiFHTTPMethod> = Method extends "GET"
-  ? Reassign<BaseTiFAPIRequest<Method>, "body", undefined>
-  : BaseTiFAPIRequest<Method>
-
-type StatusCodeMap = {
-  status200: 200
-  status201: 201
-  status204: 204
-  status400: 400
-  status401: 401
-  status403: 403
-  status404: 404
-  status429: 429
-  status500: 500
-}
-
-/**
- * A type mapping a zod schema to an http status code. The keys of the object
- * must be in the form `statusXXX`.
- */
-export type TiFAPIResponseSchemas = Partial<{
-  [key in keyof StatusCodeMap]: key extends "status204"
-    ? TiFAPINoContentSchema
-    : ZodType
-}>
-
-const EmptyObjectSchema = z.object({})
-
-type SchemaFor<
-  Key extends keyof StatusCodeMap,
-  Schemas extends TiFAPIResponseSchemas
-> = Key extends "status204"
-  ? Schemas[Key] extends TiFAPINoContentSchema
-    ? typeof EmptyObjectSchema
-    : undefined
-  : Schemas[Key]
-
-/**
- * A union type mapping a status code to the infered type of a ZodSchema.
- */
-export type TiFAPIResponse<Schemas extends TiFAPIResponseSchemas> = {
-  [key in keyof StatusCodeMap]: SchemaFor<key, Schemas> extends ZodType
-    ? {
-        status: StatusCodeMap[key]
-        data: z.infer<SchemaFor<key, Schemas>>
-      }
-    : never
-}[keyof StatusCodeMap]
-
-const FETCH_RESPONSE_EMPTY_BODY = ""
+const NoContentStatusCode = 204
 
 const log = logger("tif.api.client")
 
 /**
- * Creates a low-level fetch function to fetch from the TiF API.
- *
- * This lower level fetch handles automatic session tracking and
- * response parsing. The {@link TiFAPI} class provides a set of
- * high-level wrapper functions that utilize this low level
- * fetch function.
- *
- * ```ts
- * const apiFetch = tifAPITransport(
- *   TEST_BASE_URL,
- *   middleware
- * )
- *
- * const ResponseSchema = {
- *   status400: z.object({ b: z.string() }),
- *   status200: z.object({ a: z.number() })
- * }
- *
- * const resp = await apiFetch(
- *   {
- *     method: "POST",
- *     endpoint: "/test",
- *     query: { hello: "world", a: 1 },
- *     body: { a: 1, b: "hello" }
- *   },
- *   ResponseSchema
- * )
- *
- * if (resp.status === 200) {
- *   console.log(resp.data.a) // a is inferred to be a number.
- * }
- * ```
+ * TiFAPIMiddleware that fetches data from a given url for clients of TiFAPI.
  *
  * @param baseURL the base url of the backend to use.
- * @param loadAuthBearerToken a function that returns the loaded JWT.
- * @returns a function to make an API call.
+ * @param middleware a function to modify the fetch call.
+ * @returns TiFAPIMiddleware to construct an instance of a TiFAPIClient.
  */
-export const tifAPITransport = (baseURL: URL, middleware: TiFAPITransportMiddleware) => {
-  return async <
-    Method extends TiFHTTPMethod,
-    Schemas extends TiFAPIResponseSchemas
-  >(
-    request: TiFAPIRequest<Method>,
-    responseSchemas: Schemas,
-    signal?: AbortSignal
-  ): Promise<TiFAPIResponse<Schemas>> => {
-    try {
-      const resp = await performRequest(request, middleware, baseURL, signal)
-      const json = await tryResponseBody(resp)
-      const schema = tryResponseSchema(resp.status, responseSchemas, json)
-      return {
-        status: resp.status,
-        data: await tryParseBody(json, resp.status, schema)
-      } as TiFAPIResponse<Schemas>
-    } catch (error) {
-      if (!(error instanceof DOMException) || error.name !== "AbortError") {
-        log.error("Failed to make tif API request.", {
-          error,
-          errorMessage: error.message,
-          request
-        })
-      }
-      throw error
-    }
-  }
-}
+export const tifAPITransport = (baseURL: URL, middleware: TiFAPITransportMiddleware): EndpointSchemaToMiddleware =>
+  (endpointName, { httpRequest: { endpoint, method } }) => 
+    async ({ body, query, params, signal } = {}) => {
+      try {
+        const resp = await performRequest(
+          method, 
+          middleware, 
+          urlString({baseURL, endpoint, params, query}), 
+          body,
+          signal
+        )
+        
+        const data = await tryResponseBody(resp)
+        
+        if (data && resp.status === NoContentStatusCode) {
+          throw new Error(
+            `TiFAPI responded with a 204 status code and body ${JSON.stringify(data)}. A 204 status code should not produce a body.`
+          )
+        }
 
-/**
- * A type defining a function that can perform fetches to the TiFAPi.
- */
-export type TiFAPITransport = ReturnType<typeof tifAPITransport>
+        return {
+          // NB: typescript doesn't properly expect the union of status codes
+          status: resp.status as StatusCodeMap[keyof StatusCodeMap] as any,
+          data,
+        }
+      } catch (error) {
+        if (!(error instanceof DOMException) || error.name !== "AbortError") {
+          log.error("Failed to make tif API request.", {
+            error,
+            errorMessage: error.message,
+            input: {body, query, params},
+            endpointName
+          })
+        }
+        throw error
+      }
+    }
 
 const performRequest = async (
-  request: TiFAPIRequest<TiFHTTPMethod>,
+  method: HTTPMethod,
   middleware: TiFAPITransportMiddleware,
-  baseURL: URL,
+  url: string,
+  body?: APIRequestBody,
   signal?: AbortSignal
 ) => {
-  const searchParams = queryToSearchParams(request.query ?? {})
-  const url = `${baseURL}${request.endpoint.slice(1)}?${searchParams}`
   return await middleware(
     {
-      method: request.method,
+      method,
       headers: {
         "Content-Type": "application/json"
       },
-      body: JSON.stringify(request.body),
+      body: JSON.stringify(body),
       signal
     },
     (request) => fetch(url, request)
   )
 }
 
-const tryResponseSchema = (
-  status: number,
-  schemas: TiFAPIResponseSchemas,
-  json: unknown
-) => {
-  const statusKey = `status${status}` as keyof StatusCodeMap
-  const schema = schemas[statusKey]
-  if (!schema) {
-    throw new Error(
-      `TiF API responded with an unexpected status code ${status} and body ${JSON.stringify(json)}`
-    )
-  }
-  return schema
-}
-
-const tryParseBody = async (
-  json: unknown,
-  status: number,
-  responseSchema: ZodSchema | "no-content"
-) => {
-  if (responseSchema === "no-content" && json !== FETCH_RESPONSE_EMPTY_BODY) {
-    throw new Error(
-      `TiFAPI responded with a 204 status code and body ${JSON.stringify(json)}. A 204 status code should not produce a body.`
-    )
-  } else if (responseSchema === "no-content") {
-    return {}
-  } else {
-    try {
-      return await responseSchema.parseAsync(json)
-    } catch (e) {
-      if (e instanceof ZodError) {
-        log.trace("Zod Schema Error Message", {
-          zodError: JSON.parse(e.message)
-        })
-      }
-      throw new Error(
-        `TiF API responded with an invalid JSON body ${JSON.stringify(
-          json
-        )} and status ${status}.`
-      )
-    }
-  }
-}
-
 const tryResponseBody = async (resp: Response) => {
   try {
-    return await resp.json()
+    const body = await resp.json()
+    return body
   } catch {
-    if (resp.status !== 204) {
+    if (resp.status !== NoContentStatusCode) {
       throw new Error(
         `TiF API responded with non-JSON body and status ${resp.status}.`
       )
     }
-    return FETCH_RESPONSE_EMPTY_BODY
+    return undefined
   }
-}
-
-const queryToSearchParams = (query: TiFAPIRequestQueryParameters) => {
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(query)) {
-    if (!value) continue
-    params.set(key, value.toString())
-  }
-  return params
 }

--- a/api/TransportMiddleware.ts
+++ b/api/TransportMiddleware.ts
@@ -3,7 +3,7 @@ import { Middleware } from "lib/Middleware"
 export type TiFAPITransportMiddleware = Middleware<RequestInit, Response>
 
 /**
- * Transport middleware that a JWT bearer token to the outgoing request.
+ * Transport middleware that adds a JWT bearer token to the outgoing request.
  */
 export const jwtMiddleware = (
   jwt: () => Promise<string | undefined>

--- a/api/TransportTypes.ts
+++ b/api/TransportTypes.ts
@@ -1,0 +1,114 @@
+import { JSONSerializableValue, NonEmptyPartial } from "lib/Types/HelperTypes";
+import { StrictExtends } from "lib/Types/StrictExtendsType";
+import { URLEndpoint, URLParameters } from "lib/URL";
+import { ZodType, ZodTypeAny, z } from "zod";
+import { Handler, Middleware } from "../lib/Middleware";
+
+export type HTTPMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+
+export type APIRequestBody = { [key: string]: JSONSerializableValue }
+
+export type StatusCodeMap = {
+  status200: 200
+  status201: 201
+  status204: 204
+  status400: 400
+  status401: 401
+  status403: 403
+  status404: 404
+  status429: 429
+  status500: 500
+}
+
+type APINoContentSchema = "no-content"
+
+type APIResponseSchemas = NonEmptyPartial<{
+  [key in keyof StatusCodeMap]: key extends "status204"
+    ? APINoContentSchema
+    : ZodType
+}>
+
+const EmptyObjectSchema = z.object({})
+
+type SchemaFor<
+  Key extends keyof StatusCodeMap,
+  Schemas extends APIResponseSchemas
+> = Key extends "status204"
+  ? Schemas[Key] extends APINoContentSchema
+    ? typeof EmptyObjectSchema
+    : undefined
+  : Schemas[Key]
+
+type TiFAPIResponse<Schemas extends APIResponseSchemas> = {
+  [key in keyof StatusCodeMap]: SchemaFor<key, Schemas> extends ZodType
+    ? {
+        status: StatusCodeMap[key]
+        data: z.infer<SchemaFor<key, Schemas>>
+      }
+    : never
+}[keyof StatusCodeMap]
+
+type TiFAPIInput = {
+  body?: APIRequestBody;
+  query?: URLParameters;
+  params?: URLParameters;
+  signal?: AbortSignal
+} | void;
+
+export type GenericEndpointSchema = EndpointSchema<any, any> | EndpointSchema<InputSchema | Omit<InputSchema, "body"> | {}, any>
+
+/**
+ * Generic API endpoint middleware
+ */
+export type APIMiddleware = Middleware<TiFAPIInput, TiFAPIResponse<any>>;
+
+/**
+ * Generic API endpoint function
+ */
+export type APIHandler = Handler<TiFAPIInput, TiFAPIResponse<any>>;
+
+/**
+ * Transforms endpoint schemas into middleware for API implementations.
+ */
+export type EndpointSchemaToMiddleware = (endpointName: string, endpointSchema: GenericEndpointSchema) => APIMiddleware;
+
+/**
+ * Type asserts an endpoint schema.
+ */
+export const assertEndpointSchemaType = <TInput extends InputSchema, TOutput extends APIResponseSchemas>(
+  endpoint: EndpointSchema<
+    StrictExtends<InputSchema, TInput>, 
+    StrictExtends<APIResponseSchemas, TOutput>
+  >
+) => endpoint 
+
+/**
+ * Map of endpoint schemas.
+ */
+export type APISchema = Record<string, GenericEndpointSchema>
+
+/**
+ * Transforms a map of endpoint schemas to a map of functions where the inputs and outputs are inferred from the endpoint schemas.
+ */
+export type EndpointSchemasToFunctions<T extends APISchema> = { [K in keyof T]: (_: {} extends T[K]['input'] ? void : APIRequest<T[K]['input']> & {signal?: AbortSignal}) => Promise<TiFAPIResponse<T[K]['outputs']>>}
+
+type InputSchema = {
+  body?: ZodTypeAny;
+  query?: ZodTypeAny;
+  params?: ZodTypeAny;
+};
+
+type InferOrNever<T> = T extends ZodTypeAny ? z.infer<T> : never;
+
+type APIRequest<T extends InputSchema> = keyof T extends never ? void : {
+  [K in keyof T]: T[K] extends ZodTypeAny ? InferOrNever<T[K]> : undefined;
+};
+
+type HttpRequest<T extends HTTPMethod> = { method: T; endpoint: URLEndpoint; }
+
+type EndpointSchema<TInput extends InputSchema, TOutput extends APIResponseSchemas> = {
+  input: TInput;
+  outputs: TOutput;
+  constraints?: (input: APIRequest<TInput>, output: TiFAPIResponse<TOutput>) => boolean;
+  httpRequest: "body" extends keyof TInput ? HttpRequest<Exclude<HTTPMethod, "GET">> : HttpRequest<HTTPMethod>;
+}

--- a/api/implementAPI.test.ts
+++ b/api/implementAPI.test.ts
@@ -1,0 +1,375 @@
+import { z } from "zod";
+import { tifAPITransport } from "./Transport";
+import { APISchema, EndpointSchemasToFunctions, HTTPMethod } from "./TransportTypes";
+import { implementAPI } from "./implementAPI";
+import { MockAPIImplementation, mockAPIServer } from "./mockAPIServer";
+
+const TEST_BASE_URL = "http://localhost:8080"
+const TEST_ENDPOINT = "/test"
+
+const mockAPI = <T extends APISchema>({endpointSchema, endpointMocks}: {
+  endpointSchema: T,
+  endpointMocks: {
+    [EndpointName in keyof EndpointSchemasToFunctions<T>]: MockAPIImplementation<EndpointSchemasToFunctions<T>[EndpointName]>
+  }
+}) => 
+  mockAPIServer(new URL(TEST_BASE_URL), endpointSchema, endpointMocks)
+
+const apiClient = <T extends APISchema>(endpointSchema: T, implementations?: EndpointSchemasToFunctions<T>) => 
+  implementAPI(
+    endpointSchema,
+    tifAPITransport(
+      new URL(TEST_BASE_URL),
+      async (request, next) => next(request)
+    ),
+    implementations
+  )
+
+describe("implementAPI tests", () => {
+  it("should throw an error when performing an invalid request", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {
+          query: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status204: "no-content"
+        },
+        httpRequest: {
+          method: "GET" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            mockResponse: { 
+              status: 200,
+              data: undefined
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser()
+    ).rejects.toThrow(
+      new Error("Making an invalid request to TiF API endpoint checkUser: {}")
+    )
+  })
+  
+  it("should throw an error when performing an unexpected request", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {
+          query: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status204: "no-content"
+        },
+        httpRequest: {
+          method: "GET" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            expectedRequest: {query: {name: "John"}} as any,
+            mockResponse: { 
+              status: 200,
+              data: undefined
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser({query: {name: "Johnny"}} as any)
+    ).rejects.toThrow(
+      new Error(`TiF API responded with an unexpected status code 500 and body \
+{\
+"endpoint":"/test",\
+"expectedRequest":{"query":{"name":"John"}},\
+"actualRequest":{"params":{},"query":{"name":"Johnny"}}\
+}`
+      )
+    )
+  })
+
+  it("should throw an error when performing GET request with a body", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string()
+          })
+        },
+        httpRequest: {
+          method: "GET" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            expectedRequest: {
+              body: { name: "John" }
+            } as any,
+            mockResponse: { 
+              status: 200,
+              data: { name: 'John Doe' }
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser({body: {name: "Johnny"}} as any)
+    ).rejects.toEqual(
+      new Error(
+        "Request with GET/HEAD method cannot have body"
+      )
+    )
+  })
+  
+  it("should throw an error when server returns invalid data", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {},
+        outputs: {
+          status204: "no-content"
+        },
+        httpRequest: {
+          method: "GET" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            expectedRequest: undefined,
+            mockResponse: { 
+              status: 200,
+              data: { name: 'John Doe' }
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser()
+    ).rejects.toEqual(
+      new Error(
+        `TiF API responded with an unexpected status code 200 and body {"name":"John Doe"}`
+      )
+    )
+  })
+  
+  it("should perform a valid GET request", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {
+          query: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+            age: z.number()
+          })
+        },
+        httpRequest: {
+          method: "GET" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            expectedRequest: {
+              query: { name: "John" }
+            } as any,
+            mockResponse: { 
+              status: 200,
+              data: { name: 'John Doe', age: 30 }
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser({ query: { name: "John" } } as any)
+    ).resolves.toStrictEqual({
+      status: 200,
+      data: { name: 'John Doe', age: 30 }
+    })
+  })
+  
+  it("should perform a valid POST request", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {
+          body: z.object({
+            name: z.string(),
+          })
+        },
+        outputs: {
+          status200: z.object({
+            name: z.string(),
+            age: z.number()
+          })
+        },
+        httpRequest: {
+          method: "POST" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    let savedRequest = undefined;
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            expectedRequest: {
+              body: { name: "John" }
+            } as any,
+            handler: (request) => savedRequest = request,
+            mockResponse: { 
+              status: 200,
+              data: { name: 'John Doe', age: 30 }
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser({ body: { name: "John" } } as any)
+    ).resolves.toStrictEqual({
+      status: 200,
+      data: { name: 'John Doe', age: 30 }
+    })
+    expect(savedRequest).toMatchObject({ body: { name: "John" } })
+  })
+  
+  it("should allow no-content responses", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {},
+        outputs: {
+          status204: "no-content"
+        },
+        httpRequest: {
+          method: "GET" as HTTPMethod,
+          endpoint: TEST_ENDPOINT
+        }
+      }
+    } as APISchema
+
+    mockAPI(
+      {
+        endpointSchema,
+        endpointMocks: {
+          checkUser: {
+            mockResponse: { 
+              status: 204,
+              data: undefined
+            } as unknown as never
+          }
+        }
+      }
+    )
+
+    await expect(
+      apiClient(endpointSchema).checkUser()
+    ).resolves.toStrictEqual({
+      status: 204,
+      data: undefined
+    })
+  })
+  
+  it("should allow custom implementations per endpoint", async () => {
+    const endpointSchema = {
+      checkUser: {
+        input: {},
+        outputs: {
+          status200: z.object({
+            name: z.string()
+          })
+        }
+      },
+      updateUser: {
+        input: {
+          body: z.object({
+            id: z.number()
+          })
+        },
+        outputs: {
+          status204: "no-content"
+        }
+      }
+    } as any as APISchema
+
+    const client = implementAPI(
+      endpointSchema,
+      undefined,
+      {
+        checkUser: async () => ({status: 200, data: {name: "Drake"}}) as any,
+        updateUser: async () => ({status: 204, data: undefined}) as any
+      }
+    )
+
+    await expect(
+      client.checkUser()
+    ).resolves.toStrictEqual({
+      status: 200,
+      data: {name: "Drake"}
+    })
+    
+    await expect(
+      client.updateUser({body: {id: 123}} as any)
+    ).resolves.toStrictEqual({
+      status: 204,
+      data: undefined
+    })
+  })
+})

--- a/api/implementAPI.ts
+++ b/api/implementAPI.ts
@@ -1,0 +1,37 @@
+import { NonEmptyArray } from "lib/Types/HelperTypes";
+import { MatchFnCollection } from "lib/Types/MatchType";
+import { runMiddleware } from "../lib/Middleware";
+import { tryParseAPICall } from "./APIValidation";
+import { APIHandler, APIMiddleware, APISchema, EndpointSchemaToMiddleware, EndpointSchemasToFunctions, GenericEndpointSchema } from "./TransportTypes";
+
+export type EndpointSchemaFunction = (_: {endpointName: string, endpointSchema: GenericEndpointSchema}) => void
+
+export type APIImplementationCollector = (endpointName: string, endpointSchema: GenericEndpointSchema, __: APIHandler) => void
+
+export const implementAPI = <T extends APISchema, Fns extends EndpointSchemasToFunctions<T>>(
+  endpointSchemas: T,
+  endpointSchemaToMiddleware?: EndpointSchemaToMiddleware, 
+  implementations?: MatchFnCollection<EndpointSchemasToFunctions<T>, Fns>,
+  implementationCollector?: APIImplementationCollector
+) =>
+  Object.keys(endpointSchemas).reduce((api, key) => {
+    const schema = endpointSchemas[key] as GenericEndpointSchema
+
+    let TiFAPIMiddleware: NonEmptyArray<APIMiddleware> = [tryParseAPICall(key, schema)];
+
+    if (endpointSchemaToMiddleware) {
+      TiFAPIMiddleware.push(endpointSchemaToMiddleware(key, schema));
+    }
+
+    if (implementations && implementations[key as keyof T]) {
+      TiFAPIMiddleware.push(implementations[key as keyof T] as APIHandler);
+    }
+    
+    const apiImplementation = runMiddleware(...TiFAPIMiddleware)
+    
+    implementationCollector?.(key, schema, apiImplementation)
+
+    api[key as keyof T] = apiImplementation;
+
+    return api;
+  }, {} as Record<keyof T, any>) as EndpointSchemasToFunctions<any>;  

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,3 +1,5 @@
-export * from "./TiFAPI"
-export * from "./Middleware"
-export * from "./Transport"
+export * from "./TiFAPI";
+export * from "./TiFAPISchema";
+export * from "./Transport";
+export * from "./TransportMiddleware";
+

--- a/api/mockAPIServer.ts
+++ b/api/mockAPIServer.ts
@@ -1,0 +1,52 @@
+import { HttpResponse, http } from "msw";
+import { queryFromSearchParams } from "../lib/URL";
+import { mswServer } from "../test-helpers/MSW";
+import { APIHandler, APISchema, EndpointSchemasToFunctions, HTTPMethod } from "./TransportTypes";
+import { implementAPI } from "./implementAPI";
+
+export const mswBuilder = (testUrl: URL, method: HTTPMethod, endpoint: string, {expectedRequest, handler, mockResponse}: MockAPIImplementation<APIHandler>) => {
+  mswServer.use(
+    http[method.toLowerCase() as Lowercase<typeof method>](`${testUrl}${endpoint.slice(1)}`, async ({ request, params }) => {
+      let body: any
+      if (method === "GET") {
+        body = undefined
+      } else {
+        body = await request.json()
+      }
+
+      const input = {body, params, query: queryFromSearchParams(new URL(request.url))}
+    
+      if (expectedRequest) {
+        try {
+          expect(input).toMatchObject(expectedRequest)
+        } catch (e) {
+          return HttpResponse.json({endpoint, expectedRequest, actualRequest: input}, {status: 500})
+        }
+      }
+
+      handler?.(input)
+
+      return HttpResponse.json(mockResponse.data, { status: mockResponse.status })
+    })
+  );
+}
+
+export type MockAPIImplementation<Fn extends (...args: any) => any> = {
+  expectedRequest?: Parameters<Fn>[0],
+  handler?: (args: Parameters<Fn>[0]) => void,
+  mockResponse: Awaited<ReturnType<Fn>>,
+}
+
+export const mockAPIServer = <T extends APISchema>(
+  testUrl: URL,
+  endpointSchema: T,
+  endpointMocks: {
+    [EndpointName in keyof EndpointSchemasToFunctions<T>]: MockAPIImplementation<EndpointSchemasToFunctions<T>[EndpointName]>
+  }
+) => 
+  implementAPI(
+    endpointSchema,
+    undefined,
+    undefined,
+    (endpointName, { httpRequest: { method, endpoint }}) => mswBuilder(testUrl, method, endpoint, endpointMocks[endpointName as keyof EndpointSchemasToFunctions<T>] as any)
+  )

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -1,7 +1,7 @@
-import { UserSettings, UserSettingsSchema } from "../../domain-models/Settings"
-import { UserHandle, UserIDSchema } from "../../domain-models/User"
-import { tifAPIErrorSchema } from "./Error"
 import { z } from "zod"
+import { UserSettings, UserSettingsSchema } from "../../domain-models/Settings"
+import { UserHandleSchema, UserIDSchema } from "../../domain-models/User"
+import { tifAPIErrorSchema } from "./Error"
 
 export const userTiFAPIErrorSchema = <T extends z.Primitive>(literal: T) => {
   return tifAPIErrorSchema(literal).extend({
@@ -12,11 +12,15 @@ export const userTiFAPIErrorSchema = <T extends z.Primitive>(literal: T) => {
 export const UserNotFoundResponseSchema =
   userTiFAPIErrorSchema("user-not-found")
 
-export type UpdateCurrentUserProfileRequest = Partial<{
-  name: string
-  bio: string
-  handle: UserHandle
-}>
+export const UpdateCurrentUserProfileRequestSchema = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  handle: UserHandleSchema.optional()
+})
+
+export type UpdateCurrentUserProfileRequest = z.rInfer<
+  typeof UpdateCurrentUserProfileRequestSchema
+>
 
 export const UpdateUserSettingsRequestSchema = UserSettingsSchema.omit({
   version: true

--- a/lib/Types/MatchType.ts
+++ b/lib/Types/MatchType.ts
@@ -1,0 +1,94 @@
+import { Tagged } from "./HelperTypes";
+
+type MatchError<T> = Tagged<T, "MatchError">
+
+/**
+ * Compares two union types to check if they are equivalent, providing detailed error messages if not.
+ * 
+ * @typeParam T - The expected type.
+ * @typeParam U - The actual type being compared.
+ * @typeParam V - The resulting type if T and U match. Defaults to U.
+ * @returns Either the type V if T and U match, or a detailed error type with differences.
+ */
+export type Match<T, U, V = U> = 
+  [T] extends [U] ? 
+    ([U] extends [T] ? 
+      V : MatchError<{ error: 'Extra elements'; extra: Exclude<U, T>; }>
+    ) 
+  : MatchError<{ error: 'Missing elements'; missing: Exclude<T, U>; }>;
+
+// Example Usage:
+type x = 'a' | 'b';
+type y = 'a';
+
+// If x is not a complete subset of y, z will resolve to an error type with details
+type z = Match<x, y>;
+
+// z will detail the missing type ('c' in this case).
+
+/**
+ * Asserts that a given function matches an expected function definition, including parameter and return types.
+ * 
+ * @typeParam ExpectedFn - The expected function signature.
+ * @returns The function itself if it matches the ExpectedFn type, throwing a compile error if not.
+ */
+export const assertFnType = <ExpectedFn extends (...args: any[]) => any>() => 
+  <F extends ExpectedFn>(
+    fn: F & Match<ReturnType<ExpectedFn>, ReturnType<F>, F>
+  ) =>
+    fn
+
+// Example Usage:
+type ExampleFnType = (param: string, param2: string) => {
+  status: 204,
+  data: "no-content"
+} | {
+  status: 201,
+  data: number
+}
+
+// If fn does not return all possible values from ExampleFnType, a compile error will be thrown
+const fn = assertFnType<ExampleFnType>()((param, param2) => { // Params are correctly inferred to match ExampleFnType
+  if (param) {
+    return { status: 201, data: 3 };
+  }
+  return { status: 204, data: "no-content" }; // No need to specify "as const"
+});
+
+/**
+ * Asserts that a collection of functions matches an expected set of function definitions.
+ * 
+ * @typeParam ExpectedFns - A record type mapping function names to their expected signatures.
+ * @returns The collection of functions if each conforms to its corresponding type in ExpectedFns.
+ */
+export type MatchFnCollection<ExpectedFns extends Record<string, (...args: any[]) => any>, TFns extends ExpectedFns>
+  = {
+    [K in keyof ExpectedFns & keyof TFns]: Match<ReturnType<ExpectedFns[K]>, ReturnType<TFns[K]>, TFns[K]> & TFns[K]
+  }
+
+// Example usage:
+type ExampleFnTypeCollection = {
+  fn1: (param: string, param2: string) => {
+      status: 204,
+      data: string
+  } | {
+      status: 201,
+      data: number
+  },
+  fn2: (x: number) => number
+};
+
+const assertFnCollectionType = <ExpectedFns extends Record<string, (...args: any[]) => any>>() => {
+  return <Fns extends ExpectedFns>(fns: MatchFnCollection<ExpectedFns, Fns>) => fns;
+}
+
+// If fnCollection does not properly describe all fns from ExampleFnTypeCollection, a compile error will be thrown
+const fnCollection = assertFnCollectionType<ExampleFnTypeCollection>()({
+  fn1: (param, param2) => {
+      if (param) {
+          return { status: 201, data: 3 };
+      }
+      return { status: 204, data: "no-content" };
+  },
+  fn2: (x) => x * 2
+});

--- a/lib/Types/StrictExtendsType.ts
+++ b/lib/Types/StrictExtendsType.ts
@@ -1,0 +1,15 @@
+import { Tagged } from "./HelperTypes";
+
+type StrictExtendsError<T> = Tagged<T, "StrictExtendsError">
+
+export type StrictExtends<T, U> = (keyof U extends keyof T ? U : StrictExtendsError<{ error: 'Extra elements'; extra: Exclude<keyof U, keyof T> }>) & U;
+
+// Example Usage:
+type Person = {
+  name: string;
+  age: number;
+  occupation: string;
+};
+
+// If x is not a complete subset of y, z will resolve to an error type with details
+type z = StrictExtends<{name: string}, Person>;


### PR DESCRIPTION
## Problem/Purpose

When integrating API's between the front-end and back-end, it's common to run into issues where the type of data returned by the back-end doesn't quite match up with what the front-end is expecting, and vice versa. These issues are usually caused by human error (typos, subtle field name differences, differences in data shape), so this PR adds guardrails to ensure the front-end and back-end are at all times aligned on what data the API receives and returns. This should eliminate the "hold-your-breath" moment that occurs when testing a newly integrated API and give us more confidence that the integrations will work as we expect.

## Proposed Solution

Create a TiF API Schema in this format:

{
  [endpointName as string]: {
    input: {
      body?: ZodSchema,
      query?: ZodSchema,
      params?: ZodSchema
    },
    outputs (requires at least one): {
      status200?: ZodSchema,
      status201?: ZodSchema,
      status204?: "no-content",
      ...etc
    },
    constraints: (input, output) => boolean,
    httpRequest: {
      method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE",
      endpoint: "/{string}"
    }
  },
}

This allows us to derive a function type for each endpoint, so we can assert that we're using these functions properly in the front-end and that we're implementing these functions properly on the back-end.

## Implementation Steps

1. Create TiFAPISchema that matches the format described above
2. Create an identity function assertEndpointSchemaType() to assert each schema is written properly, including that endpoints with "GET" methods do not have an input body, at least one output must be defined, constraints have the proper input/outputs types, etc.
3. Create a function implementTiFAPI() that takes in a typesafe implementation of the functions described by the TiF API Schema, and returns a typesafe client.
4. Add a validation middleware to implementTiFAPI() to assert that the inputs/outputs of each function match the zod schemas at runtime.
5. Integrate the Transport function by turning it into an api middleware similar to the validation middleware.
6. Add testing utils to easily mock a TiFAPI server.

## Results

Include front-end pr
Include back-end pr

## Warnings

On the front-end and back-end repos, ensure versions are synced with the main TiFShared branch
Needs to be merged with [front-end pr] and [back-end pr]

TASK_GGom7vfS