### PR TITLE
add Literal type

### DIFF
--- a/lib/Types/LiteralType.ts
+++ b/lib/Types/LiteralType.ts
@@ -1,0 +1,28 @@
+type Primitive = string | number | boolean | null | undefined;
+
+type InferLiteral<T> = T extends Primitive ? T : never;
+
+/**
+ * Recursively infers the most specific literal type for given input.
+ * For primitives, it directly infers the literal type.
+ * For arrays, it infers each element.
+ * For objects, it infers each property.
+ * 
+ * Ex.
+ * ```ts
+ * declare function literal<T>(options: Literal<T>): T;
+ * const complexObject = literal({x: {y: 3, z: [1, 2, 3]}, w: new Date(2000)})
+ * // typeof complexObject is inferred the literal values
+ * ```
+ */
+export type Literal<T> = T extends Primitive ? InferLiteral<T> :
+  T extends Array<infer U> ? Array<Literal<U>> :
+  {
+    [P in keyof T]-?: Literal<T[P]>;
+  };
+
+// Example Usage:
+declare function literal<T>(options: Literal<T>): T;
+
+// typeof complexObject is inferred with literal values
+const complexObject = literal({x: {y: 3, z: [1, 2, 3]}, w: new Date(2000)})


### PR DESCRIPTION
(cherry picked from commit df5cc8b6dafc966f47fc739e1fac766a326123bf)

Allows us to strongly infer types of function parameters without needing an "as const" declaration.

ex.
```ts
export function resp({status, data}: Literal<T>) {
  return ({
    status,
    data
  })
}

resp({status: 200, data: { error: "user-not-found" }}) //type of data is inferred as {error: "user-not-found"} as opposed to {error: string} and type of status is inferred as 200 instead of number
```

TASK_UNTRACKED