### PR TITLE
Serializable classes

### DIFF
--- a/domain-models/ColorString.ts
+++ b/domain-models/ColorString.ts
@@ -1,13 +1,15 @@
 import { z } from "zod"
+import { Serializable } from "./Serializable"
 
 /**
  * An easy way to manipulate characteristics of color strings (Alpha, RGB, etc.).
  */
-export class ColorString {
+export class ColorString extends Serializable {
   private readonly rgbHexString: string
   readonly opacity: number
 
   private constructor(rgbaHexString: string, opacity: number) {
+    super()
     this.rgbHexString = rgbaHexString
     this.opacity = opacity
   }

--- a/domain-models/Serializable.ts
+++ b/domain-models/Serializable.ts
@@ -1,0 +1,12 @@
+import { ToStringable } from "lib/String";
+
+/**
+ * Domain models that can be easily serialized to strings
+ */
+export abstract class Serializable implements ToStringable {
+  abstract toString(): string;
+
+  toJSON() {
+    return this.toString();
+  }
+}

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -5,6 +5,7 @@ import {
   linkify
 } from "../lib/LinkifyIt"
 import { Tagged } from "../lib/Types/HelperTypes"
+import { Serializable } from "./Serializable"
 
 export type UserID = Tagged<string, "userId">
 
@@ -121,12 +122,13 @@ export type UserHandleError = "already-taken" | UserHandleParsingError
 /**
  * A class representing a valid user handle string.
  */
-export class UserHandle {
+export class UserHandle extends Serializable {
   static readonly LINKIFY_SCHEMA = "@"
 
   readonly rawValue: string
 
   private constructor(rawValue: string) {
+    super()
     this.rawValue = rawValue
   }
 


### PR DESCRIPTION
For certain domain models like ColorString and UserHandle, we would like the JSON representation to match the string representation so we can easily return them from the server without having to manually convert them to a string.

![image](https://github.com/user-attachments/assets/a6316db3-27b5-49f4-bc74-396aacd72abd)

TASK_UNTRACKED