### PR TITLE
Edit Event: Update Zod Schema

### DIFF
--- a/domain-models/Event.ts
+++ b/domain-models/Event.ts
@@ -212,7 +212,6 @@ export type EventEditLocation = z.rInfer<typeof EventEditLocationSchema>
 export const EventEditSchema = z.object({
   title: z.string().min(1).max(75),
   description: z.string(),
-  color: ColorStringSchema,
   startDate: z.date(),
   duration: z.number(),
   shouldHideAfterStartDate: z.boolean(),

--- a/domain-models/Event.ts
+++ b/domain-models/Event.ts
@@ -183,9 +183,18 @@ export type TrackableEventArrivalRegions = z.rInfer<
   typeof TrackableEventArrivalRegionsSchema
 >
 
+const EventEditCoordinateSchema = z.object({
+  type: z.literal("coordinate"),
+  value: LocationCoordinate2DSchema
+})
+const EventEditPlacemarkSchema = z.object({
+  type: z.literal("placemark"),
+  value: PlacemarkSchema
+})
+
 export const EventEditLocationSchema = z.union([
-  PlacemarkSchema,
-  LocationCoordinate2DSchema
+  EventEditCoordinateSchema,
+  EventEditPlacemarkSchema
 ])
 
 /**


### PR DESCRIPTION
The `EventEditSchema` did not work properly when validating on the frontend. Mainly, Zod would accept a `LocationCoordinate2D` as if it were a `Placemark`, and therefore it would return an empty object instead of the coordinate. This was because `Placemark` can be a completely empty object and still be valid, so Zod used the `PlacemarkSchema` when parsing a `LocationCoordinate2D`. Technically, a `LocationCoordinate2D` is a valid placemark because even having 0 placemark keys means that the object is valid.

To fix this, I added a `type` field to each union case of the `EventEditLocation` type. This way, the schema won't default to the wrong schema in the `z.union`.

## Tickets

https://trello.com/c/4I9AsAG3