### PR TITLE
Do not build js by default + Use prepare script

### DIFF
--- a/npm-scripts/prepare.ts
+++ b/npm-scripts/prepare.ts
@@ -1,0 +1,4 @@
+if (process.env.TIFSHARED_JS === 'true') { 
+  // reason: cannot use 'import' in prepare script
+  require('child_process').execSync('npm run build', { stdio: 'inherit', env: process.env })
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest --collectCoverage",
     "test:ci": "jest --ci --collectCoverage",
-    "prepare": "node -e \"if (process.env.TIFSHARED_TS !== 'true') { require('child_process').execSync('npx tsc', { stdio: 'inherit', env: process.env }); console.log('Built js package. If you would like to see the typescript version of the package, reinstall with the TIFSHARED_TS env variable set to true.') }\"",
+    "prepare": "node --loader ts-node/esm npm-scripts/prepare.ts",
     "pr": "node --loader ts-node/esm npm-scripts/auto-pr.ts",
     "build": "npx tsc"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,14 +9,12 @@
     "checkJs": true,
     "allowJs": true,
     "skipLibCheck": true,
-    "noEmit": true,
     "noImplicitAny": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
-    "strictNullChecks": true,
-    "allowImportingTsExtensions": true
+    "strictNullChecks": true
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
See https://github.com/tifapp/FitnessProjectBackend/pull/269

Default behavior now is not building JS unless env.TIFSHARED_JS is set to true.

TASK_UNTRACKED