### PR TITLE
Use peer dependencies to sync TiFShared package versions with the main project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test Shared Package
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, edited]
     branches:
       - main
 
@@ -30,7 +30,7 @@ jobs:
               
       - name: Run linter
         run: |
-          npx tsc
+          npx tsc --noEmit
 
       - name: Run tests
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@types/node-fetch": "^2.6.11",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
         "@typescript-eslint/parser": "^7.0.1",
-        "dayjs": "^1.11.10",
         "dotenv": "^16.4.5",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^8.8.0",
@@ -26,14 +25,17 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
         "jest": "^29.7.0",
-        "linkify-it": "^5.0.0",
         "msw": "^2.1.7",
         "node-fetch": "^3.3.2",
         "open": "^10.1.0",
         "prettier": "^3.2.5",
         "prettier-eslint": "^16.3.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.4.2",
+        "typescript": "^5.4.2"
+      },
+      "peerDependencies": {
+        "dayjs": "^1.11.10",
+        "linkify-it": "^5.0.0",
         "zod": "^3.22.4"
       }
     },
@@ -3374,7 +3376,7 @@
       "version": "1.11.10",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
       "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-      "dev": true
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6229,7 +6231,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
+      "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
@@ -8053,7 +8055,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true
+      "peer": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -8363,7 +8365,7 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "url": "https://github.com/tifapp/TiFShared/issues"
   },
   "homepage": "https://github.com/tifapp/TiFShared#readme",
+  "peerDependencies": {
+    "dayjs": "^1.11.10",
+    "zod": "^3.22.4",
+    "linkify-it": "^5.0.0"
+  },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@swc/jest": "^0.2.36",
@@ -28,7 +33,6 @@
     "@types/node-fetch": "^2.6.11",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
     "@typescript-eslint/parser": "^7.0.1",
-    "dayjs": "^1.11.10",
     "dotenv": "^16.4.5",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.8.0",
@@ -38,14 +42,12 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.7.0",
-    "linkify-it": "^5.0.0",
     "msw": "^2.1.7",
     "node-fetch": "^3.3.2",
     "open": "^10.1.0",
     "prettier": "^3.2.5",
     "prettier-eslint": "^16.3.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.4.2",
-    "zod": "^3.22.4"
+    "typescript": "^5.4.2"
   }
 }


### PR DESCRIPTION
For dependencies that are actually used in the main project (ex. zod, linkify) we should use peer dependencies to ensure the main project uses versions that TiFShared is compatible with.

TASK_UNTRACKED