### PR TITLE
Result optimization

### DIFF
--- a/lib/Result.test.ts
+++ b/lib/Result.test.ts
@@ -190,6 +190,13 @@ describe("Result tests", () => {
     expect(result1).toBe(result2)
     expect(observeFn).toHaveBeenCalledWith("passed" as const)
   })
+  
+  it("should allow promise results to be unwrapped", async () => {
+    expect(await promiseResult(failure("failed" as const)).unwrap()).toBe("failed")
+    expect(await promiseResult(success("passed" as const)).unwrap()).toBe("passed")
+    expect(await promiseResult(Promise.resolve(failure("failed" as const))).unwrap()).toBe("failed")
+    expect(await promiseResult(Promise.resolve(success("passed" as const))).unwrap()).toBe("passed")
+  })
 
   it("should allow promise results to be transformed", async () => {
     const currentResult = promiseResult(failure("failed" as const))


### PR DESCRIPTION
Extend the promise passed to promiseResult() rather than constructing a new promise

TASK_UNTRACKED