### PR TITLE
Update api types

### DIFF
--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,18 +1,12 @@
-import { UserHandleSchema, UserID, UserIDSchema } from "../domain-models/User"
+import { z } from "zod"
 import {
   EventAttendeesPageSchema,
   EventRegion,
   TrackableEventArrivalRegionsSchema
 } from "../domain-models/Event"
-import { z } from "zod"
+import { LocationCoordinate2D } from "../domain-models/LocationCoordinate2D"
+import { BlockedYouStatusSchema, UserHandleSchema, UserID, UserIDSchema } from "../domain-models/User"
 import { TiFAPIEndpoint, TiFAPITransport, tifAPITransport } from "./Transport"
-import {
-  UpdateCurrentUserProfileRequest,
-  UpdateUserSettingsRequest,
-  UserNotFoundResponseSchema,
-  UserSettingsResponseSchema,
-  userTiFAPIErrorSchema
-} from "./models/User"
 import { jwtMiddleware } from "./TransportMiddleware"
 import { tifAPIErrorSchema } from "./models/Error"
 import {
@@ -22,7 +16,13 @@ import {
   EventsInAreaResponseSchema,
   JoinEventResponseSchema
 } from "./models/Event"
-import { LocationCoordinate2D } from "domain-models/LocationCoordinate2D"
+import {
+  UpdateCurrentUserProfileRequest,
+  UpdateUserSettingsRequest,
+  UserNotFoundResponseSchema,
+  UserSettingsResponseSchema,
+  userTiFAPIErrorSchema
+} from "./models/User"
 
 export const TEST_API_URL = new URL("http://localhost:8080")
 
@@ -186,7 +186,7 @@ class _TiFAPIClass {
         status200: EventAttendeesPageSchema,
         status204: "no-content",
         status404: EventNotFoundErrorSchema,
-        status403: tifAPIErrorSchema("blocked-by-host")
+        status403: tifAPIErrorSchema(BlockedYouStatusSchema.value)
       }
     )
   }

--- a/api/models/Error.ts
+++ b/api/models/Error.ts
@@ -8,6 +8,5 @@ export const tifAPIErrorSchema = <
   ...literals: [...V]
 ) => {
   if (literals.length === 0) return z.object({ error: z.literal(literal) })
-  const [literal2, ...rest] = literals.map((l) => z.literal(l))
-  return z.object({ error: z.union([z.literal(literal), literal2, ...rest]) })
+  return z.object({ error: z.enum([String(literal), ...literals.map((l) => String(l))]) })
 }

--- a/api/models/Event.test.ts
+++ b/api/models/Event.test.ts
@@ -1,7 +1,7 @@
 import { ColorString } from "../../domain-models/ColorString"
-import { EventResponse, EventResponseSchema } from "./Event"
 import { dateRange } from "../../domain-models/FixedDateRange"
 import { UserHandle } from "../../domain-models/User"
+import { EventResponse, EventResponseSchema } from "./Event"
 
 describe("EventAPIModels tests", () => {
   test("event response schema", () => {
@@ -21,8 +21,7 @@ describe("EventAPIModels tests", () => {
       },
       previewAttendees: [
         {
-          id: "2fd22e4a-147c-4189-889e-15469b80eaf7",
-          profileImageURL: null
+          id: "2fd22e4a-147c-4189-889e-15469b80eaf7"
         }
       ],
       location: {
@@ -40,20 +39,17 @@ describe("EventAPIModels tests", () => {
         isInArrivalTrackingPeriod: true
       },
       host: {
-        relations: { themToYou: "not-friends", youToThem: "not-friends" },
+        relationStatus: "not-friends",
         id: "2fd22e4a-147c-4189-889e-15469b80eaf7",
-        username: "Caroline Parisian",
-        handle: "carolinepar0103",
-        profileImageURL: null
+        name: "Caroline Parisian",
+        handle: "carolinepar0103"
       },
       settings: { shouldHideAfterStartDate: true, isChatEnabled: true },
       userAttendeeStatus: "not-participating",
-      joinDate: null,
       isChatExpired: false,
       hasArrived: false,
-      updatedAt: "2024-03-25T07:54:28.000Z",
-      createdAt: "2024-03-25T07:54:28.000Z",
-      endedAt: null
+      updatedDateTime: "2024-03-25T07:54:28.000Z",
+      createdDateTime: "2024-03-25T07:54:28.000Z",
     }
     const result = EventResponseSchema.safeParse(json) as {
       data: EventResponse
@@ -74,8 +70,7 @@ describe("EventAPIModels tests", () => {
       },
       previewAttendees: [
         {
-          id: "2fd22e4a-147c-4189-889e-15469b80eaf7",
-          profileImageURL: null
+          id: "2fd22e4a-147c-4189-889e-15469b80eaf7"
         }
       ],
       location: {
@@ -93,20 +88,17 @@ describe("EventAPIModels tests", () => {
         isInArrivalTrackingPeriod: true
       },
       host: {
-        relations: { themToYou: "not-friends", youToThem: "not-friends" },
+        relationStatus: "not-friends",
         id: "2fd22e4a-147c-4189-889e-15469b80eaf7",
-        username: "Caroline Parisian",
-        handle: UserHandle.optionalParse("carolinepar0103")!,
-        profileImageURL: null
+        name: "Caroline Parisian",
+        handle: UserHandle.optionalParse("carolinepar0103")!
       },
       settings: { shouldHideAfterStartDate: true, isChatEnabled: true },
       userAttendeeStatus: "not-participating",
-      joinDate: null,
       isChatExpired: false,
       hasArrived: false,
-      updatedAt: new Date("2024-03-25T07:54:28.000Z"),
-      createdAt: new Date("2024-03-25T07:54:28.000Z"),
-      endedAt: null
+      updatedDateTime: new Date("2024-03-25T07:54:28.000Z"),
+      createdDateTime: new Date("2024-03-25T07:54:28.000Z"),
     })
   })
 })

--- a/api/models/FixedDateRange.test.ts
+++ b/api/models/FixedDateRange.test.ts
@@ -1,7 +1,8 @@
+import { ZodError } from "zod"
 import { dateRange } from "../../domain-models/FixedDateRange"
-import { FixedDateRangeSchema } from "./FixedDateRange"
+import { CreateFixedDateRangeSchema, FixedDateRangeSchema, MIN_EVENT_DURATION } from "./FixedDateRange"
 
-describe("FixedDateRangeAPI tests", () => {
+describe("FixedDateRangeSchema tests", () => {
   test("valid FixedDateRange", () => {
     expect(FixedDateRangeSchema.parse({
       startDateTime: "2023-02-25T00:19:00.00Z",
@@ -31,3 +32,52 @@ describe("FixedDateRangeAPI tests", () => {
     })).toThrow(`Start Date must be before End Date.`)
   })
 })
+
+describe("CreateFixedDateRangeSchema tests", () => {
+  const staticNow = new Date("2024-01-01T00:00:00.000Z");
+
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(staticNow);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test("valid FixedDateRange instance with sufficient duration and future end date", () => {
+    const testRange = dateRange(
+      staticNow,
+      new Date(staticNow.getTime() + (MIN_EVENT_DURATION) * 1000)
+    );
+
+    expect(CreateFixedDateRangeSchema.parse(testRange)).toEqual(testRange);
+  });
+
+  test("invalid duration and end date in the past", () => {
+    const start = new Date(staticNow.getTime() - 100000)
+
+    const testRange = dateRange(
+      start,
+      new Date(start.getTime() + (MIN_EVENT_DURATION / 2) * 1000)
+    );
+
+    try {
+      CreateFixedDateRangeSchema.parse(testRange);
+    } catch (e) {
+      if (e instanceof ZodError) {
+        expect(e.errors).toMatchObject([
+          {
+            code: "custom",
+            message: "The duration must be at least 60 seconds.",
+            fatal: true,
+          },
+          {
+            code: "custom",
+            message: "The end date cannot be in the past.",
+            fatal: true,
+          },
+        ]);
+      }
+    }
+  });
+});

--- a/api/models/FixedDateRange.ts
+++ b/api/models/FixedDateRange.ts
@@ -28,7 +28,7 @@ export const CreateFixedDateRangeSchema = FixedDateRangeSchema.superRefine((date
   const { startDateTime, endDateTime } = dateRange;
 
   const secondDiff = (endDateTime.getTime() - startDateTime.getTime()) / 1000;
-  const isEndDatePast = endDateTime < new Date();
+  const isEndDatePast = endDateTime < new Date(); // TODO: Compare with server's timezone
 
   if (secondDiff < MIN_EVENT_DURATION) {
     ctx.addIssue({

--- a/api/models/FixedDateRange.ts
+++ b/api/models/FixedDateRange.ts
@@ -16,3 +16,33 @@ export const FixedDateRangeSchema = z.optionalParseable(
     return new FixedDateRange(parsedArg.startDateTime, parsedArg.endDateTime)
   }
 )
+
+export const MIN_EVENT_DURATION = 60
+
+/**
+ * A Zod schema for creating a FixedDateRange with additional constraints for new Events:
+ * - Duration must be at least MIN_EVENT_DURATION seconds.
+ * - The end date cannot be in the past.
+ */
+export const CreateFixedDateRangeSchema = FixedDateRangeSchema.superRefine((dateRange, ctx) => {
+  const { startDateTime, endDateTime } = dateRange;
+
+  const secondDiff = (endDateTime.getTime() - startDateTime.getTime()) / 1000;
+  const isEndDatePast = endDateTime < new Date();
+
+  if (secondDiff < MIN_EVENT_DURATION) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "The duration must be at least 60 seconds.",
+      fatal: true
+    });
+  }
+
+  if (isEndDatePast) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "The end date cannot be in the past.",
+      fatal: true
+    });
+  }
+});

--- a/api/models/User.ts
+++ b/api/models/User.ts
@@ -1,7 +1,7 @@
-import { UserSettings, UserSettingsSchema } from "../../domain-models/Settings"
-import { UserHandle, UserIDSchema } from "../../domain-models/User"
-import { tifAPIErrorSchema } from "./Error"
 import { z } from "zod"
+import { UserSettings, UserSettingsSchema } from "../../domain-models/Settings"
+import { UserHandleSchema, UserIDSchema, UserToProfileRelationStatusSchema } from "../../domain-models/User"
+import { tifAPIErrorSchema } from "./Error"
 
 export const userTiFAPIErrorSchema = <T extends z.Primitive>(literal: T) => {
   return tifAPIErrorSchema(literal).extend({
@@ -12,11 +12,18 @@ export const userTiFAPIErrorSchema = <T extends z.Primitive>(literal: T) => {
 export const UserNotFoundResponseSchema =
   userTiFAPIErrorSchema("user-not-found")
 
-export type UpdateCurrentUserProfileRequest = Partial<{
-  name: string
-  bio: string
-  handle: UserHandle
-}>
+export const BlockedUserResponseSchema =
+  userTiFAPIErrorSchema("blocked")
+
+export const UpdateCurrentUserProfileRequestSchema = z.object({
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  handle: UserHandleSchema.optional()
+})
+
+export type UpdateCurrentUserProfileRequest = z.rInfer<
+  typeof UpdateCurrentUserProfileRequestSchema
+>
 
 export const UpdateUserSettingsRequestSchema = UserSettingsSchema.omit({
   version: true
@@ -29,3 +36,33 @@ export type UpdateUserSettingsRequest = z.rInfer<
 export type UserSettingsResponse = UserSettings
 
 export const UserSettingsResponseSchema = UserSettingsSchema
+
+const DevicePlatformSchema = z.enum(["apple", "android"])
+
+export const SelfProfileSchema = z.object({
+  id: UserIDSchema,
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  handle: UserHandleSchema,
+  createdDateTime: z.coerce.date(),
+  profileImageURL: z.string().url().optional(),
+  updatedDateTime: z.coerce.date(),
+})
+
+export const UserProfileSchema = z.object({
+  id: UserIDSchema,
+  name: z.string().optional(),
+  bio: z.string().optional(),
+  handle: UserHandleSchema,
+  createdDateTime: z.coerce.date(),
+  profileImageURL: z.string().url().optional(),
+  updatedDateTime: z.coerce.date(),
+  relationStatus: UserToProfileRelationStatusSchema
+})
+
+export const RegisterPushTokenRequestSchema = z.object({
+  pushToken: z.string().min(1), //generic nonempty string schema?
+  platformName: DevicePlatformSchema
+})
+
+export type DevicePlatform = z.infer<typeof DevicePlatformSchema>

--- a/domain-models/ColorString.ts
+++ b/domain-models/ColorString.ts
@@ -29,6 +29,9 @@ export class ColorString {
       this.opacity === 1 ? "" : Math.ceil(255 * this.opacity).toString(16)
     return this.rgbHexString + opacityHexString
   }
+  toJSON() {
+    return this.toString()
+  }
 
   private static RGB_HEX_STRING_LENGTH = 7
   private static REGEX = /^#([a-f0-9]{2}){3,4}$/i

--- a/domain-models/FixedDateRange.test.ts
+++ b/domain-models/FixedDateRange.test.ts
@@ -17,40 +17,40 @@ describe("FixedDateRange tests", () => {
     expect(range).toBeUndefined()
   })
 
-  test("moveStartDate basic", () => {
+  test("moveStartDateTime basic", () => {
     const range = dateRange(
       new Date("2023-02-25T00:17:00"),
       new Date("2023-02-25T00:18:00")
-    )?.moveStartDateWithAutocorrection(new Date(0))
-    expect(range?.startDate).toEqual(new Date(0))
-    expect(range?.endDate).toEqual(new Date("2023-02-25T00:18:00"))
+    )?.moveStartWithAutocorrection(new Date(0))
+    expect(range?.startDateTime).toEqual(new Date(0))
+    expect(range?.endDateTime).toEqual(new Date("2023-02-25T00:18:00"))
   })
 
-  test("moveEndDate basic", () => {
-    const newEndDate = new Date("3000-01-01T00:00:00")
+  test("moveEndDateTime basic", () => {
+    const newEndDateTime = new Date("3000-01-01T00:00:00")
     const range = dateRange(
       new Date("2023-02-25T00:17:00"),
       new Date("2023-02-25T00:18:00")
-    )?.moveEndDateWithAutocorrection(newEndDate)
-    expect(range?.startDate).toEqual(new Date("2023-02-25T00:17:00"))
-    expect(range?.endDate).toEqual(newEndDate)
+    )?.moveEndWithAutocorrection(newEndDateTime)
+    expect(range?.startDateTime).toEqual(new Date("2023-02-25T00:17:00"))
+    expect(range?.endDateTime).toEqual(newEndDateTime)
   })
 
   it("moving start date past end date moves end date past the start date by the previous interval between the dates", () => {
     const range = dateRange(
       new Date("2023-02-25T00:17:00"),
       new Date("2023-02-25T00:18:00")
-    )?.moveStartDateWithAutocorrection(new Date("2023-02-25T00:19:00"))
+    )?.moveStartWithAutocorrection(new Date("2023-02-25T00:19:00"))
     // NB: The previous interval was 1 minute, so we ensure the end date is 1 minute ahead of the start date
-    expect(range?.endDate).toEqual(new Date("2023-02-25T00:20:00"))
+    expect(range?.endDateTime).toEqual(new Date("2023-02-25T00:20:00"))
   })
 
   it("moving end date before start date moves start date before the end date by the previous interval between the dates", () => {
     const range = dateRange(
       new Date("2023-02-25T00:17:00"),
       new Date("2023-02-25T00:18:00")
-    )?.moveEndDateWithAutocorrection(new Date("2023-02-25T00:16:00"))
+    )?.moveEndWithAutocorrection(new Date("2023-02-25T00:16:00"))
     // NB: The previous interval was 1 minute, so we ensure the start date is 1 minute behind of the end date
-    expect(range?.startDate).toEqual(new Date("2023-02-25T00:15:00"))
+    expect(range?.startDateTime).toEqual(new Date("2023-02-25T00:15:00"))
   })
 })

--- a/domain-models/FixedDateRange.ts
+++ b/domain-models/FixedDateRange.ts
@@ -1,5 +1,4 @@
-import { z } from "zod"
-import { StringDateSchema } from "../lib/Date"
+import { ZodError, z } from "zod"
 
 /**
  * A data type to deal with a date range that has a known start and end date.
@@ -8,9 +7,9 @@ import { StringDateSchema } from "../lib/Date"
  * is fixed to the correct position using the previous interval between the 2 dates:
  *
  * ```ts
- * // Makes range.endDate "new Date(3)" because the previous interval was 1 second
+ * // Makes range.endDateTime "new Date(3)" because the previous interval was 1 second
  * const range = dateRange(new Date(0), new Date(1))?
- *   .moveStartDateWithAutocorrection(new Date(2))
+ *   .moveStartWithAutocorrection(new Date(2))
  * ```
  *
  * If the intial start date and end date are incompatible with each other, this
@@ -27,14 +26,14 @@ export class FixedDateRange {
    * The diff values are based off the end date and thus are always positive.
    */
   get diff() {
-    return this.endDate.ext.diff(this.startDate)
+    return this.endDateTime.ext.diff(this.startDateTime)
   }
 
   constructor(
-    readonly startDate: Date,
-    readonly endDate: Date
+    readonly startDateTime: Date,
+    readonly endDateTime: Date
   ) {
-    if (startDate > endDate) {
+    if (startDateTime > endDateTime) {
       throw new Error("Start Date must be before End Date.")
     }
   }
@@ -43,24 +42,24 @@ export class FixedDateRange {
    * Sets the start date of this range adjusting the end date ahead of the
    * start date by amount of the previous interval between the 2 dates.
    */
-  moveStartDateWithAutocorrection(date: Date) {
-    const { seconds } = date.ext.diff(this.endDate)
-    if (date > this.endDate) {
+  moveStartWithAutocorrection(date: Date) {
+    const { seconds } = date.ext.diff(this.endDateTime)
+    if (date > this.endDateTime) {
       return new FixedDateRange(date, date.ext.addSeconds(seconds))
     }
-    return new FixedDateRange(date, this.endDate)
+    return new FixedDateRange(date, this.endDateTime)
   }
 
   /**
    * Sets the start date of this range adjusting the start date to be behind
    * the end date by amount of the previous interval between the 2 dates.
    */
-  moveEndDateWithAutocorrection(date: Date) {
-    const { seconds } = date.ext.diff(this.startDate)
-    if (date < this.startDate) {
+  moveEndWithAutocorrection(date: Date) {
+    const { seconds } = date.ext.diff(this.startDateTime)
+    if (date < this.startDateTime) {
       return new FixedDateRange(date.ext.addSeconds(seconds), date)
     }
-    return new FixedDateRange(this.startDate, date)
+    return new FixedDateRange(this.startDateTime, date)
   }
 }
 

--- a/domain-models/Settings.ts
+++ b/domain-models/Settings.ts
@@ -1,26 +1,26 @@
 import { z } from "zod"
-import { PlacemarkSchema } from "./Placemark"
+import { EventEditLocationSchema } from "./Event"
 
 export const UserSettingsVersionSchema = z.number().nonnegative()
 
 export type UserSettingsVersion = z.infer<typeof UserSettingsVersionSchema>
 
-export const EventCalendarWeekdaySchema = z.union([
-  z.literal("sunday"),
-  z.literal("monday"),
-  z.literal("tuesday"),
-  z.literal("wednesday"),
-  z.literal("thursday"),
-  z.literal("friday"),
-  z.literal("saturday")
+export const EventCalendarWeekdaySchema = z.enum([
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday"
 ])
 
 export type EventCalendarWeekdayID = z.infer<typeof EventCalendarWeekdaySchema>
 
-export const EventCalendarLayoutIDSchema = z.union([
-  z.literal("single-day-layout"),
-  z.literal("week-layout"),
-  z.literal("month-layout")
+export const EventCalendarLayoutIDSchema = z.enum([
+  "single-day-layout",
+  "week-layout",
+  "month-layout"
 ])
 
 export type EventCalendarLayoutID = z.infer<typeof EventCalendarLayoutIDSchema>
@@ -28,20 +28,20 @@ export type EventCalendarLayoutID = z.infer<typeof EventCalendarLayoutIDSchema>
 /**
  * A zod schema for {@link PushNotificationTriggerID}.
  */
-export const PushNotificationTriggerIDSchema = z.union([
-  z.literal("friend-request-received"),
-  z.literal("friend-request-accepted"),
-  z.literal("user-entered-region"),
-  z.literal("event-attendance-headcount"),
-  z.literal("event-periodic-arrivals"),
-  z.literal("event-starting-soon"),
-  z.literal("event-started"),
-  z.literal("event-ended"),
-  z.literal("event-name-changed"),
-  z.literal("event-description-changed"),
-  z.literal("event-time-changed"),
-  z.literal("event-location-changed"),
-  z.literal("event-cancelled")
+export const PushNotificationTriggerIDSchema = z.enum([
+  "friend-request-received",
+  "friend-request-accepted",
+  "user-entered-region",
+  "event-attendance-headcount",
+  "event-periodic-arrivals",
+  "event-starting-soon",
+  "event-started",
+  "event-ended",
+  "event-name-changed",
+  "event-description-changed",
+  "event-time-changed",
+  "event-location-changed",
+  "event-cancelled"
 ])
 
 /**
@@ -121,7 +121,7 @@ export const UserSettingsSchema = z.object({
   eventCalendarStartOfWeekDay: EventCalendarWeekdaySchema,
   eventCalendarDefaultLayout: EventCalendarLayoutIDSchema,
   eventPresetShouldHideAfterStartDate: z.boolean(),
-  eventPresetPlacemark: PlacemarkSchema.nullable(),
+  eventPresetLocation: EventEditLocationSchema.optional(),
   eventPresetDurations: z.array(z.number()),
   version: UserSettingsVersionSchema
 })
@@ -165,7 +165,7 @@ export const DEFAULT_USER_SETTINGS = {
   eventCalendarStartOfWeekDay: "monday",
   eventCalendarDefaultLayout: "week-layout",
   eventPresetDurations: [900, 1800, 2700, 3600, 5400],
-  eventPresetPlacemark: null,
+  eventPresetLocation: undefined,
   eventPresetShouldHideAfterStartDate: false,
   version: 0
 } satisfies Readonly<UserSettings>

--- a/domain-models/TodayOrTomorrow.ts
+++ b/domain-models/TodayOrTomorrow.ts
@@ -1,8 +1,8 @@
 import { z } from "zod"
 
-export const TodayOrTomorrowSchema = z.union([
-  z.literal("today"),
-  z.literal("tomorrow")
+export const TodayOrTomorrowSchema = z.enum([
+  "today",
+  "tomorrow"
 ])
 
 export type TodayOrTomorrow = z.infer<typeof TodayOrTomorrowSchema>

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -13,19 +13,19 @@ export const UserIDSchema = z
   .uuid()
   .transform((id) => id as UserID)
 
+export const BlockedYouStatusSchema = z.literal("blocked-you")
+export const BlockedThemStatusSchema = z.literal("blocked-them")
 export const NotFriendsStatusSchema = z.literal("not-friends")
-export const FriendRequestPendingStatusSchema = z.literal(
-  "friend-request-pending"
-)
+export const FriendRequestSentStatusSchema = z.literal("friend-request-sent")
+export const FriendRequestReceivedStatusSchema = z.literal("friend-request-received")
 export const FriendsStatusSchema = z.literal("friends")
-export const BlockedStatusSchema = z.literal("blocked")
 export const CurrentUserStatusSchema = z.literal("current-user")
 
 export const UserToProfileRelationStatusSchema = z.union([
   NotFriendsStatusSchema,
-  FriendRequestPendingStatusSchema,
+  FriendRequestSentStatusSchema,
   FriendsStatusSchema,
-  BlockedStatusSchema,
+  BlockedThemStatusSchema,
   CurrentUserStatusSchema
 ])
 
@@ -43,65 +43,37 @@ export type UserToProfileRelationStatus = z.rInfer<
   typeof UserToProfileRelationStatusSchema
 >
 
-export const BlockedBidirectionalUserRelationsSchema = z.union([
-  z.object({
-    themToYou: BlockedStatusSchema,
-    youToThem: BlockedStatusSchema
-  }),
-  z.object({
-    themToYou: BlockedStatusSchema,
-    youToThem: NotFriendsStatusSchema
-  })
-])
 
 /**
  * A 2-way relationship from a user to another profile where at least one party
  * involved is blocking the other.
  */
-export type BlockedBidirectionalUserRelations = z.rInfer<
-  typeof BlockedBidirectionalUserRelationsSchema
+export type BlockedUserRelationsStatus = z.rInfer<
+  typeof BlockedYouStatusSchema
 >
 
-export const UnblockedBidirectionalUserRelationsSchema = z.union([
-  z.object({
-    themToYou: NotFriendsStatusSchema,
-    youToThem: NotFriendsStatusSchema
-  }),
-  z.object({
-    themToYou: FriendRequestPendingStatusSchema,
-    youToThem: NotFriendsStatusSchema
-  }),
-  z.object({
-    themToYou: NotFriendsStatusSchema,
-    youToThem: BlockedStatusSchema
-  }),
-  z.object({
-    themToYou: NotFriendsStatusSchema,
-    youToThem: FriendRequestPendingStatusSchema
-  }),
-  z.object({
-    themToYou: FriendsStatusSchema,
-    youToThem: FriendsStatusSchema
-  }),
-  z.object({
-    themToYou: CurrentUserStatusSchema,
-    youToThem: CurrentUserStatusSchema
-  })
+export const UnblockedUserRelationsSchema = z.enum([
+  BlockedThemStatusSchema.value,
+  NotFriendsStatusSchema.value,
+  FriendRequestSentStatusSchema.value,
+  FriendRequestReceivedStatusSchema.value,
+  FriendsStatusSchema.value,
+  CurrentUserStatusSchema.value
 ])
 
 /**
  * A 2-way relationship from a user to another profile where no party is blocking the other.
  */
-export type UnblockedBidirectionalUserRelations = z.rInfer<
-  typeof UnblockedBidirectionalUserRelationsSchema
+export type UnblockedUserRelationsStatus = z.rInfer<
+  typeof UnblockedUserRelationsSchema
 >
 
 /**
  * A descriptor of a 2-way relationship between 2 users.
  */
-export type BidirectionalUserRelations =
-  | UnblockedBidirectionalUserRelations
-  | BlockedBidirectionalUserRelations
+export type UserRelationsStatus =
+  | UnblockedUserRelationsStatus
+  | BlockedUserRelationsStatus
 
 /**
  * An reason that a user handle's raw text was unable to be parsed.

--- a/lib/Date.ts
+++ b/lib/Date.ts
@@ -1,6 +1,5 @@
 import { dayjs } from "./Dayjs"
 import { Extension, protoypeExtension } from "./Extend"
-import { z } from "zod"
 
 export type DateUnit = dayjs.ManipulateType
 
@@ -58,11 +57,3 @@ const extensions = {
 }
 
 protoypeExtension(Date, extensions)
-
-/**
- * A zod schema that parses from a string to a date.
- */
-export const StringDateSchema = z
-  .string()
-  .datetime()
-  .transform((date) => new Date(date))


### PR DESCRIPTION
Our zod schemas are encoded in the api spec and then deployed to AWS.
Zod unions get converted to "anyOf" fields in the spec, which isn't supported by AWS unfortunately.

https://github.com/tifapp/FitnessProjectBackend/actions/runs/10954197483/job/30415882552
![image](https://github.com/user-attachments/assets/a2fd14eb-bf5a-4b90-b9d2-8fda97953148)

This PR modifies the problematic schemas to be compatible with AWS' api requirements, particularly replacing union schemas with enum schemas. There are also other schema changes to align with the backend api integration.

Major changes:
* The "themToYou"/"youToThem" statuses are replaced with an easier-to-understand "userRelations" enum. 
![image](https://github.com/user-attachments/assets/070a1cc1-0c5a-444d-88e6-24de4d90c7c1)
* updatedAt/createdAt fields renamed to updatedDateTime/createdDateTime for clarity
* Nullable fields changed to Optionals for requests and responses
* StringDateSchema replaced with z.coerce.date(), which accepts both string dates and Date objects
* Added request schemas for CreateEvent, EditEvent, UpdateUserProfile, GetUser, GetSelf and RegisterPushToken endpoints
* Added CreateFixedDateRangeSchema for the CreateEvent endpoint. Contains extra validation logic
* OptionalParseable allows objects of the same type to pass through

TASK_UNTRACKED