### PR TITLE
Allow optional baseurls

### DIFF
--- a/lib/URL.test.ts
+++ b/lib/URL.test.ts
@@ -28,6 +28,20 @@ describe('URL Utils', () => {
   });
   
   describe('urlString', () => {
+    it('should construct a URL with a simple endpoint and no baseURL', () => {
+      const endpoint: URLEndpoint = '/endpoint';
+      const result = urlString({endpoint});
+      expect(result).toBe('/endpoint');
+    });
+    
+    it('should construct a URL with both query and path parameters and no baseURL', () => {
+      const endpoint: URLEndpoint = '/endpoint/:id/:action';
+      const params: URLParameters = { id: '123', action: 'edit' };
+      const query: URLParameters = { foo: 'bar', baz: 'qux' };
+      const result = urlString({endpoint, params, query});
+      expect(result).toBe('/endpoint/123/edit?foo=bar&baz=qux');
+    });
+
     it('should construct a URL with a simple endpoint and no query or params', () => {
       const baseURL = new URL('https://api.example.com');
       const endpoint: URLEndpoint = '/endpoint';

--- a/lib/URL.ts
+++ b/lib/URL.ts
@@ -6,11 +6,11 @@ export type URLParameters = {
 
 export type URLEndpoint = `/${string}`
 
-export const urlString = ({baseURL, endpoint, params, query}: {baseURL: URL, endpoint: URLEndpoint, params?: URLParameters, query?: URLParameters}) => {
+export const urlString = ({baseURL, endpoint, params, query}: {baseURL?: URL, endpoint: URLEndpoint, params?: URLParameters, query?: URLParameters}) => {
   const path = parameterizeEndpoint(endpoint, params ?? {}).slice(1)
   const searchParams = queryToSearchParams(query ?? {})
   const queryString = searchParams.toString() ? `?${searchParams}` : '';
-  return `${baseURL}${path}${queryString}`
+  return `${baseURL ?? '/'}${path}${queryString}`
 }
 
 export const queryFromSearchParams = (url: URL) => {


### PR DESCRIPTION
We use the urlString() util without a baseUrl to construct the endpoints in backend tests.

![image](https://github.com/user-attachments/assets/b5e8ace8-63e4-4a3a-8db6-72644aeff05a)

TASK_UNTRACKED
