### PR TITLE
Zod optional parseable update

### DIFF
--- a/api/models/FixedDateRange.test.ts
+++ b/api/models/FixedDateRange.test.ts
@@ -2,32 +2,32 @@ import { dateRange } from "../../domain-models/FixedDateRange"
 import { FixedDateRangeSchema } from "./FixedDateRange"
 
 describe("FixedDateRangeAPI tests", () => {
-  test("zod schema", () => {
-    let result = FixedDateRangeSchema.safeParse({
-      startDateTime: "2023-02-25T00:19:00.00Z",
-      endDateTime: "2023-02-25T00:18:00.00Z"
-    })
-    expect(result.success).toEqual(false)
-    result = FixedDateRangeSchema.safeParse({
+  test("valid FixedDateRange", () => {
+    expect(FixedDateRangeSchema.parse({
       startDateTime: "2023-02-25T00:19:00.00Z",
       endDateTime: "2023-02-25T00:20:00.00Z"
-    })
-    expect(result).toEqual({
-      success: true,
-      data: dateRange(
-        new Date("2023-02-25T00:19:00.00Z"),
-        new Date("2023-02-25T00:20:00.00Z")
-      )
-    })
-    result = FixedDateRangeSchema.safeParse({
+    })).toEqual(dateRange(
+      new Date("2023-02-25T00:19:00.00Z"),
+      new Date("2023-02-25T00:20:00.00Z")
+    ))
+  })
+
+  test("invalid dates", () => {
+    expect(() => FixedDateRangeSchema.parse({
       startDateTime: "iuahbxgwd7823823geg",
       endDateTime: "2023-02-25T00:18:00.00Z"
-    })
-    expect(result.success).toEqual(false)
-    result = FixedDateRangeSchema.safeParse({
+    })).toThrow("Invalid date")
+    
+    expect(() => FixedDateRangeSchema.parse({
       startDateTime: "2023-02-25T00:18:00.00Z",
       endDateTime: "899832ue982hdh"
-    })
-    expect(result.success).toEqual(false)
+    })).toThrow("Invalid date")
+  })
+  
+  test("start date before end date", () => {
+    expect(() => FixedDateRangeSchema.parse({
+      startDateTime: "2023-02-25T00:19:00.00Z",
+      endDateTime: "2023-02-25T00:18:00.00Z"
+    })).toThrow(`Start Date must be before End Date.`)
   })
 })

--- a/api/models/FixedDateRange.ts
+++ b/api/models/FixedDateRange.ts
@@ -1,26 +1,18 @@
-import { dateRange } from "../../domain-models/FixedDateRange"
-import { StringDateSchema } from "../../lib/Date"
 import { z } from "zod"
-
-export type StringDateRangeResponse = {
-  startDateTime: string
-  endDateTime: string
-}
+import { FixedDateRange } from "../../domain-models/FixedDateRange"
 
 /**
  * A zod schema to parse an {@link FixedDateRange} where the start and end dates
  * are represented as raw date strings.
  */
 export const FixedDateRangeSchema = z.optionalParseable(
-  {
-    parse: ({ startDateTime, endDateTime }: StringDateRangeResponse) => {
-      const sDate = StringDateSchema.safeParse(startDateTime)
-      const eDate = StringDateSchema.safeParse(endDateTime)
-      if (!sDate.success || !eDate.success) return undefined
-      return dateRange(sDate.data, eDate.data)
-    }
-  },
-  () => {
-    return `Response must have startDateTime before endDateTime.`
+  FixedDateRange,
+  (arg: {startDateTime: string, endDateTime: string}) => {
+    const parsedArg = z.object({
+      startDateTime: z.coerce.date(),
+      endDateTime: z.coerce.date()
+    }).parse(arg)
+    
+    return new FixedDateRange(parsedArg.startDateTime, parsedArg.endDateTime)
   }
 )

--- a/domain-models/ColorString.test.ts
+++ b/domain-models/ColorString.test.ts
@@ -1,4 +1,4 @@
-import { ColorString } from "./ColorString"
+import { ColorString, ColorStringSchema } from "./ColorString"
 
 describe("ColorString tests", () => {
   it("should parse rrggbb color strings", () => {
@@ -44,5 +44,15 @@ describe("ColorString tests", () => {
     expect(ColorString.parse("#ffffff")?.withOpacity(0.49).toString()).toEqual(
       "#ffffff7d"
     )
+  })
+
+  describe("ColorStringSchema", () => {
+    test("success", () => {
+      expect(ColorStringSchema.parse("#ffffff")).toEqual(ColorString.parse("#ffffff"))
+    })
+    
+    test("failure", () => {
+      expect(() => ColorStringSchema.parse("iojoigfiowejf")).toThrow("Invalid hex color string.")
+    })
   })
 })

--- a/domain-models/ColorString.ts
+++ b/domain-models/ColorString.ts
@@ -62,6 +62,15 @@ export class ColorString {
  * A zod schema for {@link ColorString}.
  */
 export const ColorStringSchema = z.optionalParseable(
+  // @ts-ignore Typescript error - Constructor is private
   ColorString,
-  () => `Invalid hex color string.`
+  (rawValue: string) => {
+    const parsedValue = ColorString.parse(z.string().parse(rawValue));
+
+    if (!parsedValue) {
+      throw new Error("Invalid hex color string.")
+    }
+    
+    return parsedValue
+  }
 )

--- a/domain-models/User.test.ts
+++ b/domain-models/User.test.ts
@@ -1,5 +1,5 @@
 import { linkify } from "../lib/LinkifyIt"
-import { UserHandle, UserHandleLinkifyMatch } from "./User"
+import { UserHandle, UserHandleLinkifyMatch, UserHandleSchema } from "./User"
 
 describe("User tests", () => {
   describe("UserHandle tests", () => {
@@ -45,6 +45,7 @@ describe("User tests", () => {
         "Hello @user @hello, make sure@interlinked names aren't parsed. Also the name has to be @valid(#*&$. @*($&) @world Now for a @superduperlongname"
       const matches = linkify
         .match(str)
+        //@ts-expect-error extends Match
         ?.map((m: UserHandleLinkifyMatch) => m.userHandle.toString())
       expect(matches).toEqual([
         "@user",
@@ -54,5 +55,29 @@ describe("User tests", () => {
         "@superduperlongn"
       ])
     })
+  })
+  
+  describe("UserHandleSchema tests", () => {
+    test("should successfully parse valid user handles", () => {
+      const result = UserHandleSchema.parse("user123");
+      expect(result).toBeInstanceOf(UserHandle);
+      expect(JSON.stringify(result)).toBe("\"user123\"");
+    });
+  
+    test("should fail to parse empty string", () => {
+      expect(() => UserHandleSchema.parse("")).toThrow(`A valid user handle must have at least 1 character.`)
+    });
+  
+    test("should fail to parse strings with invalid characters", () => {
+      expect(() => UserHandleSchema.parse("kbnf&*(&*(")).toThrow(`A valid user handle only contains letters, numbers, and underscores.`);
+    });
+  
+    test("should fail to parse strings that are too long", () => {
+      expect(() => UserHandleSchema.parse("thishandleiswaytoolong")).toThrow(`A valid user handle can only be up to 15 characters long.`)
+    });
+  
+    test("should fail to parse non-string types", () => {
+      expect(() => UserHandleSchema.parse(123)).toThrow("Expected string, received number");
+    });
   })
 })

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -202,11 +202,20 @@ export class UserHandle {
  * A zod schema that converts a string to an {@link UserHandle}.
  */
 export const UserHandleSchema = z.optionalParseable(
-  {
-    parse: (rawValue: string) => UserHandle.optionalParse(rawValue)
-  },
-  () => {
-    return "A valid user handle only contains letters, numbers, underscores, and can only be upto 15 characters long."
+  // @ts-ignore Typescript error - Constructor is private
+  UserHandle,
+  (arg: UserHandle | string) => {
+    const parseResult = UserHandle.parse(z.string().parse(arg))
+
+    if (parseResult.error === "bad-format") {
+      throw new Error("A valid user handle only contains letters, numbers, and underscores.")
+    } else if (parseResult.error === "empty") {
+      throw new Error("A valid user handle must have at least 1 character.")
+    } else if (parseResult.error === "too-long") {
+      throw new Error("A valid user handle can only be up to 15 characters long.")
+    } else {
+      return parseResult.handle
+    }
   }
 )
 

--- a/lib/Types/HelperTypes.ts
+++ b/lib/Types/HelperTypes.ts
@@ -87,3 +87,7 @@ export type Reassign<Obj, Key extends keyof Obj, Type> = {
  */
 export type Tagged<T, Tag extends string> = T & { _tag?: Tag }
 
+/**
+ * Represents any class or object with a constructor method
+ */
+export type Constructor = new (...args: any) => any;

--- a/lib/Zod.ts
+++ b/lib/Zod.ts
@@ -1,31 +1,37 @@
-import { ZodSchema, z } from "zod"
+import { ZodError, ZodIssue, ZodSchema, z } from "zod"
+import { Constructor } from "./Types/HelperTypes"
 
-/**
- * An interface which defines a method of parsing that returns either an output type or `undefined`.
- */
-export interface OptionalParseable<Input, Output> {
-  parse(input: Input): Output | undefined
-}
-
-const optionalParse = <Input, Output>(
-  parseable: OptionalParseable<Input, Output>,
-  errorMessage?: (input: Input) => string
+const optionalParse = <Input, Output extends Constructor>(
+  constructor: Output,
+  parse: (input: Input) => InstanceType<Output>
 ) => {
-  let parsedValue: Output | undefined
+  let parsedValue: InstanceType<Output>
   return z
     .custom<Input>()
     .superRefine((arg, ctx) => {
-      parsedValue = parseable.parse(arg)
-      if (!parsedValue) {
-        const message = errorMessage?.(arg)
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `${message ? message + " " : ""}(Received: ${arg})`,
-          fatal: true
-        })
+      if (arg instanceof constructor) {
+        parsedValue = arg as InstanceType<Output>
+        return
+      }
+
+      try {
+        parsedValue = parse(arg)
+      } catch (e) {
+        if (e instanceof ZodError) {
+          e.issues.forEach((issue: ZodIssue) => {
+            ctx.addIssue(issue);
+          });
+        } else {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: e.message,
+            params: { arg },
+            fatal: true
+          })
+        }
       }
     })
-    .transform(() => parsedValue!)
+    .transform(() => parsedValue) // NB: Needed to return the parsed value
 }
 
 declare module "zod" {
@@ -52,10 +58,10 @@ declare module "zod" {
      * @param errorMessage a function that gets the error message when parsing fails.
      * @returns a zod schema that wraps the parseable.
      */
-    function optionalParseable<Input, Output>(
-      parseable: OptionalParseable<Input, Output>,
-      errorMessage?: (input: Input) => string
-    ): ReturnType<typeof optionalParse<Input, Output>>
+    function optionalParseable<Input, Output extends Constructor>(
+      constructor: Output,
+      parseable: (input: Input) => InstanceType<Output>
+    ): ReturnType<typeof optionalParse<Input, InstanceType<Output>>>
 
     /**
      * Infers a zod schema as a "Readonly" type.


### PR DESCRIPTION
Purpose: Complex optional parseable schemas may have multiple different possible validation errors. The current implementation decouples the parsing from the error message, making it difficult to return various error messages from the result of the parse.
Ex.
![image](https://github.com/user-attachments/assets/02a597b6-eba1-4e42-b459-2d70cc0ba174)

Proposed Solution: Allow validation errors to be thrown from the parsing function.

Results:
Allows zod errors within the parseable to be propagated.
Allows multiple error messages per optionalParseable schema.
Examples:
![image](https://github.com/user-attachments/assets/8dbcaa80-66fe-4986-98aa-678edeaba791)
![image](https://github.com/user-attachments/assets/e1f77475-46f8-40f0-bc89-77e03bf1f74f)

Other issues: 
It's difficult to read the original arg from the custom error message, especially when the arg is a deep object. I attempted to wrap it with a JSON.stringify() to make it readable, but then found that zod wraps the custom error in another JSON.stringify(), which still makes it difficult to read and validate in tests.
Solution: Use the params field of ZodErrors to hold the parseable arg.

Current:
![image](https://github.com/user-attachments/assets/94c346aa-2af0-456f-adee-73bc2cb70f1b)
Attempted Fix:
![image](https://github.com/user-attachments/assets/2a3d1835-82e1-4ada-b47f-1d6bdc6e46dd)

New:
![image](https://github.com/user-attachments/assets/cb2de16b-d5b5-49ce-a2a9-3bd925ff51a5)

Other changes:
Modify zod schemas to allow the same instance to pass through

TASK_UNTRACKED