### PR TITLE
Zod optionalparseable - Fix zod inferred type and change type signature

### DIFF
--- a/api/models/FixedDateRange.ts
+++ b/api/models/FixedDateRange.ts
@@ -7,14 +7,11 @@ import { FixedDateRange } from "../../domain-models/FixedDateRange"
  */
 export const FixedDateRangeSchema = z.optionalParseable(
   FixedDateRange,
-  (arg: {startDateTime: string, endDateTime: string}) => {
-    const parsedArg = z.object({
+  z.object({
       startDateTime: z.coerce.date(),
       endDateTime: z.coerce.date()
-    }).parse(arg)
-    
-    return new FixedDateRange(parsedArg.startDateTime, parsedArg.endDateTime)
-  }
+    })
+    .transform(({startDateTime, endDateTime}) => new FixedDateRange(startDateTime, endDateTime))
 )
 
 export const MIN_EVENT_DURATION = 60

--- a/domain-models/ColorString.ts
+++ b/domain-models/ColorString.ts
@@ -65,15 +65,15 @@ export class ColorString {
  * A zod schema for {@link ColorString}.
  */
 export const ColorStringSchema = z.optionalParseable(
-  // @ts-ignore Typescript error - Constructor is private
   ColorString,
-  (rawValue: string) => {
-    const parsedValue = ColorString.parse(z.string().parse(rawValue));
+  z.string()
+    .transform(rawValue => {
+      const parsedValue = ColorString.parse(rawValue);
 
-    if (!parsedValue) {
-      throw new Error("Invalid hex color string.")
-    }
-    
-    return parsedValue
-  }
+      if (!parsedValue) {
+        throw new Error("Invalid hex color string.")
+      }
+      
+      return parsedValue
+    })
 )

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -178,21 +178,21 @@ export class UserHandle {
  * A zod schema that converts a string to an {@link UserHandle}.
  */
 export const UserHandleSchema = z.optionalParseable(
-  // @ts-ignore Typescript error - Constructor is private
   UserHandle,
-  (arg: UserHandle | string) => {
-    const parseResult = UserHandle.parse(z.string().parse(arg))
+  z.string()
+    .transform(rawValue => {
+      const {error, handle} = UserHandle.parse(rawValue)
 
-    if (parseResult.error === "bad-format") {
-      throw new Error("A valid user handle only contains letters, numbers, and underscores.")
-    } else if (parseResult.error === "empty") {
-      throw new Error("A valid user handle must have at least 1 character.")
-    } else if (parseResult.error === "too-long") {
-      throw new Error("A valid user handle can only be up to 15 characters long.")
-    } else {
-      return parseResult.handle
-    }
-  }
+      if (handle) {
+        return handle
+      } else if (error === "empty") {
+        throw new Error("A valid user handle must have at least 1 character.")
+      } else if (error === "too-long") {
+        throw new Error("A valid user handle can only be up to 15 characters long.")
+      } else {        
+        throw new Error("A valid user handle only contains letters, numbers, and underscores.")
+      }
+    })
 )
 
 export type UserHandleLinkifyMatch = Match & { userHandle: UserHandle }

--- a/lib/Types/HelperTypes.ts
+++ b/lib/Types/HelperTypes.ts
@@ -87,7 +87,4 @@ export type Reassign<Obj, Key extends keyof Obj, Type> = {
  */
 export type Tagged<T, Tag extends string> = T & { _tag?: Tag }
 
-/**
- * Represents any class or object with a constructor method
- */
-export type Constructor = new (...args: any) => any;
+export type Prototype = Function & { prototype: any };

--- a/lib/Zod.test.ts
+++ b/lib/Zod.test.ts
@@ -10,9 +10,7 @@ describe("ExtendedZod tests", () => {
     }
   }
   
-  const PositiveSchema = z.optionalParseable(Positive, (rawValue: number) => {
-    return new Positive(z.number().parse(rawValue))
-  })
+  const PositiveSchema = z.optionalParseable(Positive, z.number().transform(rawValue => new Positive(rawValue)))
 
   test("optional parseable, basic", () => {
     let result = PositiveSchema.safeParse(-1)

--- a/lib/Zod.ts
+++ b/lib/Zod.ts
@@ -1,21 +1,29 @@
-import { ZodError, ZodIssue, ZodSchema, z } from "zod"
-import { Constructor } from "./Types/HelperTypes"
+import { ZodError, ZodIssue, ZodSchema, ZodType, ZodTypeDef, z } from "zod"
+import { Prototype } from "./Types/HelperTypes"
 
-const optionalParse = <Input, Output extends Constructor>(
-  constructor: Output,
-  parse: (input: Input) => InstanceType<Output>
+/**
+ * optionalParse creates a Zod schema that accepts either an instance of a class
+ * or raw input that can be transformed into an instance of that class.
+ *
+ * @param clazz - The class (can have public or private constructor).
+ * @param schema - A Zod schema that validates and transforms raw input into the desired Output type.
+ * @returns A Zod schema that accepts either an instance of the class or raw input.
+ */
+const optionalParse = <Output extends Prototype, Input>(
+  clazz: Output,
+  schema: ZodType<Output, ZodTypeDef, Input>
 ) => {
-  let parsedValue: InstanceType<Output>
+  let parsedValue: Output
   return z
     .custom<Input>()
     .superRefine((arg, ctx) => {
-      if (arg instanceof constructor) {
-        parsedValue = arg as InstanceType<Output>
+      if (arg instanceof clazz) {
+        parsedValue = arg as unknown as Output
         return
       }
 
       try {
-        parsedValue = parse(arg)
+        parsedValue = schema.parse(arg)
       } catch (e) {
         if (e instanceof ZodError) {
           e.issues.forEach((issue: ZodIssue) => {
@@ -58,10 +66,10 @@ declare module "zod" {
      * @param errorMessage a function that gets the error message when parsing fails.
      * @returns a zod schema that wraps the parseable.
      */
-    function optionalParseable<Input, Output extends Constructor>(
+    function optionalParseable<Output extends Prototype, Input>(
       constructor: Output,
-      parseable: (input: Input) => InstanceType<Output>
-    ): ReturnType<typeof optionalParse<Input, InstanceType<Output>>>
+      schema: ZodType<Output["prototype"], ZodTypeDef, Input>
+    ): ZodType<Output["prototype"], ZodTypeDef, Input>
 
     /**
      * Infers a zod schema as a "Readonly" type.


### PR DESCRIPTION
The previous Zod update removed proper type inference from the custom schemas. https://github.com/tifapp/TiFShared/pull/65

![image](https://github.com/user-attachments/assets/87d25e6f-0a7d-42ec-8eb8-9ae6e31c7b34)

This pr fixes that and simplifies the usage by accepting a direct zod schema and inferring the input/output from it.

![image](https://github.com/user-attachments/assets/2c175143-87c9-4ffa-9e55-72e8843512f9)

TASK_UNTRACKED