### PR TITLE
OptionalParseable async behavior

### DIFF
--- a/lib/Zod.test.ts
+++ b/lib/Zod.test.ts
@@ -16,7 +16,10 @@ describe("ExtendedZod tests", () => {
     let result = PositiveSchema.safeParse(-1)
     expect(result.success).toEqual(false)
     result = PositiveSchema.safeParse(1)
-    expect(result.success).toEqual(true)
+    expect(result).toEqual({
+      success: true,
+      data: new Positive(1)
+    })
   })
   
   test("optional parseable, pass instances of the constructor", () => {
@@ -50,4 +53,15 @@ describe("ExtendedZod tests", () => {
       }
     ])
   })
+  
+  test("optional parseable should not overwrite previous values in an async context", async () => {
+    const testInput = [new Positive(1), new Positive(2), new Positive(3)]
+
+    const result = await z.array(PositiveSchema).parseAsync(testInput)
+
+    expect(result).toStrictEqual(testInput)
+  })
+
+  // NB: Issues are duplicated in an async context
+  // Ex. await z.array(PositiveSchema).parseAsync([1, -2, -3])
 })


### PR DESCRIPTION
OptionalParseable would override previous values in an async context, probably due to the global parsedValue. This PR fixes it by keeping the parsed value within the custom() method and persisting the errors globally instead.

![image](https://github.com/user-attachments/assets/f634a7aa-45cf-4718-bf88-5c05477d25d2)

![image](https://github.com/user-attachments/assets/f336079f-8912-4cb0-a859-8ef50e9aeeff)

TASK_UNTRACKED
