### PR TITLE
Array Shuffle Extension

### DIFF
--- a/lib/Array.test.ts
+++ b/lib/Array.test.ts
@@ -1,4 +1,5 @@
 import { pollyfillArray, repeatElements } from "./Array"
+import { shallowEquals } from "./ShallowEquals"
 
 describe("TiFArray tests", () => {
   describe("ArrayExtensions tests", () => {
@@ -60,6 +61,21 @@ describe("TiFArray tests", () => {
     test("repeat elements, based on index", () => {
       const array = repeatElements(5, (i) => i)
       expect(array).toEqual([0, 1, 2, 3, 4])
+    })
+
+    test("shuffle produces different combinations of arrays", () => {
+      const arrays = repeatElements(10, () => repeatElements(10, (i) => i)).map(
+        (arr) => arr.ext.shuffled()
+      )
+      let differencesCount = 0
+      for (const array in arrays) {
+        for (const comparison in arrays) {
+          if (!shallowEquals(array, comparison)) {
+            differencesCount++
+          }
+        }
+      }
+      expect(differencesCount).toBeGreaterThanOrEqual(70)
     })
   })
 

--- a/lib/Array.ts
+++ b/lib/Array.ts
@@ -50,6 +50,19 @@ const extensions = <T>() => ({
    */
   randomElement: (array: T[], randomValue: () => number = Math.random) => {
     return array[Math.floor(array.length * randomValue())]
+  },
+  /**
+   * Returns a copied shuffled version of this array using the Fisher-Yates algorithm.
+   *
+   * @param randomValue See {@link Math.random}.
+   */
+  shuffled: (array: T[], randomValue: () => number = Math.random) => {
+    const shuffled = [...array]
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(randomValue() * (i + 1))
+      ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+    }
+    return shuffled
   }
 })
 


### PR DESCRIPTION
Copies the array shuffle method from [Sean's prototype PR](https://github.com/tifapp/FitnessProject/pull/413/files/d68829cad4bef0960a88c82a50b550d2bac014c8#diff-66284dbac825b054a1a0355c2ebfd984a86096e710abd17176cfea26cb8964e7).

## Tickets

https://trello.com/c/u74wFpA8/805-seans-prototype