### PR TITLE
JWT Body Parsing

### DIFF
--- a/lib/JWT.test.ts
+++ b/lib/JWT.test.ts
@@ -1,0 +1,37 @@
+import { jwtBody } from "./JWT"
+
+describe("JWT tests", () => {
+  describe("JWTBody tests", () => {
+    it.each([
+      "",
+      "dkjhkjdhkjhdkhkdikhojodjs",
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQSflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxN.TE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    ])("should return undefined for %s", (invalidJwt: string) => {
+      expect(jwtBody(invalidJwt)).toEqual(undefined)
+    })
+
+    it.each([
+      [
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        { sub: "1234567890", name: "John Doe", iat: 1516239022 }
+      ],
+      [
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDIsIm5hbWUiOiJCaXRjaGVsbCBEaWNrbGUifQ.UfbiTs-VWvxagoAk1YkJ9HzrjQiMY_2Ln7Op_BjN_xg",
+        {
+          id: 42,
+          name: "Bitchell Dickle"
+        }
+      ],
+      [
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U",
+        {}
+      ]
+    ])(
+      "should return the body contents of %s",
+      (jwt: string, body: Record<string, any>) => {
+        expect(jwtBody(jwt)).toEqual(body)
+      }
+    )
+  })
+})

--- a/lib/JWT.ts
+++ b/lib/JWT.ts
@@ -1,0 +1,18 @@
+/**
+ * Parses and returns an object containing the body of a JWT without verifying its signature.
+ *
+ * Do not use this function as the sole-validator of the contents of a JWT, because it does not
+ * verify the token signature.
+ *
+ * @param jwt The JWT to parse.
+ * @returns An object of the body if `jwt` is a valid jwt, or undefined otherwise.
+ */
+export const jwtBody = (jwt: string): unknown | undefined => {
+  const indicies = [] as number[]
+  for (let i = 0; i < jwt.length; i++) {
+    if (jwt[i] === ".") indicies.push(i)
+  }
+  if (indicies.length !== 2) return undefined
+  const bodyBase64 = jwt.substring(indicies[0] + 1, indicies[1])
+  return JSON.parse(atob(bodyBase64.replace(/-/g, "+").replace(/_/g, "/")))
+}


### PR DESCRIPTION
The Rudeus Editor frontend needs to be able to parse the user details from the JWT that the Rudeus Server signs. I suspect that we will do something similar for the alpha of the main app, so I have moved this generic function to parse the body of a JWT without verifying it here.

## Tickets

https://trello.com/c/tF0FfaJ6