### PR TITLE
More API Genericization

### DIFF
--- a/api/APIClient.test.ts
+++ b/api/APIClient.test.ts
@@ -1,39 +1,52 @@
-import { z } from "zod";
-import { mockAPIServer, mockEndpointSchema } from "../test-helpers/mockAPIServer";
-import { APIClientCreator } from "./APIClient";
-import { TEST_API_URL, validateAPIClientCall } from "./TiFAPI";
-import { tifAPITransport } from "./Transport";
-import { APISchema } from "./TransportTypes";
+import { z } from "zod"
+import {
+  mockAPIServer,
+  mockEndpointSchema
+} from "../test-helpers/mockAPIServer"
+import { APIClientCreator } from "./APIClient"
+import { TEST_API_URL, validateTiFAPIClientCall } from "./TiFAPI"
+import { tifAPITransport } from "./Transport"
+import { APISchema } from "./TransportTypes"
 
 const TEST_BASE_URL = "http://localhost:8080"
 
-const mockAPI = <T extends APISchema>(endpointSchema: T, expectedRequest?: any, mockResponse?: any, handler?: any) => {
-  mockAPIServer(new URL(TEST_BASE_URL), endpointSchema, {checkUser: {expectedRequest, mockResponse, handler}} as any)
+const mockAPI = <T extends APISchema>(
+  endpointSchema: T,
+  expectedRequest?: any,
+  mockResponse?: any,
+  handler?: any
+) => {
+  mockAPIServer(new URL(TEST_BASE_URL), endpointSchema, {
+    checkUser: { expectedRequest, mockResponse, handler }
+  } as any)
 
-  return APIClientCreator(    
+  return APIClientCreator(
     endpointSchema,
-    validateAPIClientCall,
+    validateTiFAPIClientCall,
     tifAPITransport(TEST_API_URL)
   )
 }
 
-describe("MockAPIServer tests", () => {  
+describe("MockAPIServer tests", () => {
   it("should throw an error when performing an unexpected request", async () => {
     const apiClient = mockAPI(
-      mockEndpointSchema("GET", { query: z.object({ name: z.string(), }) }),
+      mockEndpointSchema("GET", { query: z.object({ name: z.string() }) }),
       { query: { name: "John" } } as any
     )
 
-    let error = undefined;
+    let error = undefined
 
     try {
-      await apiClient.checkUser({query: {name: "Johnny"}} as any)
+      await apiClient.checkUser({ query: { name: "Johnny" } } as any)
     } catch (e) {
       // NB: error occurs in the mock api server so it can't be caught normally
-      error = e.cause.matcherResult.message.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+      error = e.cause.matcherResult.message.replace(
+        /\x1B\[[0-?]*[ -/]*[@-~]/g,
+        ""
+      )
     }
 
-     expect(error).toEqual(
+    expect(error).toEqual(
       `expect(received).toMatchObject(expected)
 
 - Expected  - 1
@@ -47,33 +60,39 @@ describe("MockAPIServer tests", () => {
   }`
     )
   }),
-  
-  
-  it("should perform a valid GET request", async () => {
-    const mockResponse = { 
-      status: 200,
-      data: { name: 'John Doe' }
-    }
+    it("should perform a valid GET request", async () => {
+      const mockResponse = {
+        status: 200,
+        data: { name: "John Doe" }
+      }
 
-    const apiClient = mockAPI(
-      mockEndpointSchema("GET", { query: z.object({ name: z.string(), }) }, { status200: z.object({ name: z.string() }) }),
-      undefined,
-      mockResponse
-    )
+      const apiClient = mockAPI(
+        mockEndpointSchema(
+          "GET",
+          { query: z.object({ name: z.string() }) },
+          { status200: z.object({ name: z.string() }) }
+        ),
+        undefined,
+        mockResponse
+      )
 
-    await expect(
-      apiClient.checkUser({ query: { name: "John" } } as any)
-    ).resolves.toStrictEqual(mockResponse)
-  })
+      await expect(
+        apiClient.checkUser({ query: { name: "John" } } as any)
+      ).resolves.toStrictEqual(mockResponse)
+    })
 
   it("should perform a valid POST request with an undefined body", async () => {
-    const mockResponse = { 
+    const mockResponse = {
       status: 200,
-      data: { name: 'John Doe' }
+      data: { name: "John Doe" }
     }
 
     const apiClient = mockAPI(
-      mockEndpointSchema("POST", { body: z.undefined() }, { status200: z.object({ name: z.string() })}),
+      mockEndpointSchema(
+        "POST",
+        { body: z.undefined() },
+        { status200: z.object({ name: z.string() }) }
+      ),
       { body: undefined },
       mockResponse
     )
@@ -87,65 +106,61 @@ describe("MockAPIServer tests", () => {
 describe("APIClient tests", () => {
   it("should throw an error when performing an invalid request", async () => {
     const apiClient = mockAPI(
-      mockEndpointSchema("GET", { query: z.object({ name: z.string(), }) }),
+      mockEndpointSchema("GET", { query: z.object({ name: z.string() }) })
     )
 
-    await expect(
-      apiClient.checkUser()
-    ).rejects.toThrow(
+    await expect(apiClient.checkUser()).rejects.toThrow(
       new Error("invalid-request")
     )
   })
 
   it("should throw an error when performing GET request with a body", async () => {
     const apiClient = mockAPI(
-      mockEndpointSchema("GET", { body: z.object({ name: z.string(), }) }),
+      mockEndpointSchema("GET", { body: z.object({ name: z.string() }) })
     )
 
     await expect(
-      apiClient.checkUser({body: {name: "Johnny"}} as any)
+      apiClient.checkUser({ body: { name: "Johnny" } } as any)
     ).rejects.toEqual(
-      new Error(
-        "Request with GET/HEAD method cannot have body"
-      )
+      new Error("Request with GET/HEAD method cannot have body")
     )
   })
-  
+
   it("should throw an error when server returns unexpected data", async () => {
     const apiClient = mockAPI(
       mockEndpointSchema("GET", {}, { status204: "no-content" }),
       undefined,
-      { status: 200, data: { name: 'John Doe' } }
+      { status: 200, data: { name: "John Doe" } }
     )
 
-    await expect(
-      apiClient.checkUser()
-    ).rejects.toEqual(
+    await expect(apiClient.checkUser()).rejects.toEqual(
       new Error("unexpected-response")
     )
   })
-  
+
   it("should throw an error when server returns invalid data", async () => {
     const apiClient = mockAPI(
-      mockEndpointSchema("GET", {}, { status200: z.object({ age: z.number() }) }),
+      mockEndpointSchema(
+        "GET",
+        {},
+        { status200: z.object({ age: z.number() }) }
+      ),
       undefined,
-      { status: 200, data: { name: 'John Doe' } }
+      { status: 200, data: { name: "John Doe" } }
     )
 
-    await expect(
-      apiClient.checkUser()
-    ).rejects.toEqual(
+    await expect(apiClient.checkUser()).rejects.toEqual(
       new Error("invalid-response")
     )
   })
-  
+
   it("should perform a valid POST request", async () => {
-    let savedRequest = undefined;
+    let savedRequest = undefined
 
     const apiClient = mockAPI(
       mockEndpointSchema(
-        "POST", 
-        { body: z.object({ name: z.string() }) }, 
+        "POST",
+        { body: z.object({ name: z.string() }) },
         {
           status200: z.object({
             age: z.number()
@@ -153,24 +168,22 @@ describe("APIClient tests", () => {
         }
       ),
       undefined,
-      { 
+      {
         status: 200,
         data: { age: 30 }
       },
-      (request) => savedRequest = request ?? undefined
+      (request) => (savedRequest = request ?? undefined)
     )
 
     await expect(
       apiClient.checkUser({ body: { name: "John" } } as any)
-    ).resolves.toStrictEqual(
-      {
-        status: 200,
-        data: { age: 30 }
-      }
-    )
+    ).resolves.toStrictEqual({
+      status: 200,
+      data: { age: 30 }
+    })
     expect(savedRequest).toMatchObject({ body: { name: "John" } })
   })
-  
+
   it("should allow no-content responses", async () => {
     const apiClient = mockAPI(
       mockEndpointSchema("GET", {}, { status204: "no-content" }),
@@ -178,9 +191,7 @@ describe("APIClient tests", () => {
       { status: 204, data: undefined }
     )
 
-    await expect(
-      apiClient.checkUser()
-    ).resolves.toStrictEqual({
+    await expect(apiClient.checkUser()).resolves.toStrictEqual({
       status: 204,
       data: undefined
     })

--- a/api/APIValidation.ts
+++ b/api/APIValidation.ts
@@ -1,8 +1,17 @@
 import { ZodError, ZodTypeAny, z } from "zod"
-import { logger } from "../logging"
-import { APIMiddleware, AnyTiFAPIResponse, TiFAPIInputContext } from "./TransportTypes"
+import { Logger, logger } from "../logging"
+import {
+  APIMiddleware,
+  AnyTiFAPIResponse,
+  TiFAPIInputContext
+} from "./TransportTypes"
+import { ClientExtensions } from "./Transport"
 
-export type ValidationResult = "invalid-request" | "unexpected-response" | "invalid-response" | "passed"
+export type ValidationResult =
+  | "invalid-request"
+  | "unexpected-response"
+  | "invalid-response"
+  | "passed"
 
 export class APIValidationError extends Error {
   validationResult: ValidationResult
@@ -14,32 +23,39 @@ export class APIValidationError extends Error {
   }
 }
 
-const log = logger("tif.api.validation")
+export const DEFAULT_LOG = logger("tif.api.validation")
 
-const zodValidation = async <T>(data: T, schema: ZodTypeAny): Promise<T | "failure"> => {
+const zodValidation = async <T>(
+  data: T,
+  schema: ZodTypeAny,
+  log: Logger
+): Promise<T | "failure"> => {
   try {
-      return await schema.parseAsync(data)
+    return await schema.parseAsync(data)
   } catch (e) {
-      if (e instanceof ZodError) {
-          log.error("Zod Schema Error Message", {
-              zodError: JSON.parse(e.message)
-          })
-      } else {
-          log.error(e)
-      }
-      return "failure"
+    if (e instanceof ZodError) {
+      log.error("Zod Schema Error Message", {
+        zodError: JSON.parse(e.message)
+      })
+    } else {
+      log.error(e)
+    }
+    return "failure"
   }
 }
 
-export type ValidationResultParser<T> = 
-  (_: {
-    validationStatus: "invalid-request", 
-    requestContext: TiFAPIInputContext<T>
-  } | {
-    validationStatus: "unexpected-response" | "invalid-response" | "passed", 
-    requestContext: TiFAPIInputContext<T>, 
-    response: AnyTiFAPIResponse
-  }) => AnyTiFAPIResponse
+export type ValidationResultParser<T> = (
+  _:
+    | {
+        validationStatus: "invalid-request"
+        requestContext: TiFAPIInputContext<T>
+      }
+    | {
+        validationStatus: "unexpected-response" | "invalid-response" | "passed"
+        requestContext: TiFAPIInputContext<T>
+        response: AnyTiFAPIResponse
+      }
+) => AnyTiFAPIResponse
 
 export enum APIValidationOptions {
   None = 0,
@@ -47,17 +63,40 @@ export enum APIValidationOptions {
   Response = 1 << 1
 }
 
-export const validateAPICall = <T>(resultParser: ValidationResultParser<T>, validationOptions: APIValidationOptions = APIValidationOptions.Request | APIValidationOptions.Response): APIMiddleware<T> => 
-  async (requestContext, next) => {
-    const {endpointSchema: {input: inputSchema, outputs: outputSchemas, constraints}, body, query, params} = requestContext
+export const API_VALIDATION_OPTIONS_ALL: APIValidationOptions =
+  APIValidationOptions.Request | APIValidationOptions.Response
 
-    let request = {body, query, params}
+export const validateAPICall = <T>(
+  resultParser: ValidationResultParser<T>,
+  validationOptions: APIValidationOptions = API_VALIDATION_OPTIONS_ALL,
+  log: Logger = DEFAULT_LOG
+): APIMiddleware<T> => {
+  return async (requestContext, next) => {
+    const {
+      endpointSchema: {
+        input: inputSchema,
+        outputs: outputSchemas,
+        constraints
+      },
+      body,
+      query,
+      params
+    } = requestContext
+
+    let request = { body, query, params }
 
     if (validationOptions & APIValidationOptions.Request) {
-      const validatedRequest = await zodValidation(request, z.object(inputSchema))
-      
+      const validatedRequest = await zodValidation(
+        request,
+        z.object(inputSchema),
+        log
+      )
+
       if (validatedRequest === "failure") {
-        return resultParser({validationStatus: "invalid-request", requestContext})
+        return resultParser({
+          validationStatus: "invalid-request",
+          requestContext
+        })
       } else {
         request = validatedRequest
       }
@@ -66,27 +105,69 @@ export const validateAPICall = <T>(resultParser: ValidationResultParser<T>, vali
     Object.assign(requestContext, request)
 
     const response = await next(requestContext)
-    
+
     let validationStatus: ValidationResult = "passed"
 
     let responseData = response.data
 
     if (validationOptions & APIValidationOptions.Response) {
-      const responseSchema = outputSchemas[`status${response.status}` as keyof typeof outputSchemas] as ZodTypeAny | "no-content"
+      const responseSchema = outputSchemas[
+        `status${response.status}` as keyof typeof outputSchemas
+      ] as ZodTypeAny | "no-content"
 
       if (!responseSchema) {
         validationStatus = "unexpected-response"
       } else if (responseSchema !== "no-content") {
         responseData = await zodValidation(
-          response.data, 
-          responseSchema.refine(() => constraints ? constraints(request, response) : true),
+          response.data,
+          responseSchema.refine(() =>
+            constraints ? constraints(request, response) : true
+          ),
+          log
         )
-        
+
         if (responseData === "failure") {
           validationStatus = "invalid-response"
         }
       }
     }
 
-    return resultParser({validationStatus, requestContext, response: {status: response.status, data: responseData}})
+    return resultParser({
+      validationStatus,
+      requestContext,
+      response: { status: response.status, data: responseData }
+    })
   }
+}
+
+export const validateAPIClientCall = (
+  apiName: string,
+  log: Logger,
+  validationOptions: APIValidationOptions = API_VALIDATION_OPTIONS_ALL
+) => {
+  return validateAPICall<ClientExtensions>(
+    (result) => {
+      if (result.validationStatus === "passed") {
+        return result.response
+      } else if (result.validationStatus === "invalid-request") {
+        log.error(
+          `Request to ${apiName} API endpoint ${result.requestContext.endpointName} is not valid`,
+          result.requestContext
+        )
+      } else if (result.validationStatus === "unexpected-response") {
+        log.error(
+          `${apiName} API endpoint ${result.requestContext.endpointName} responded unexpectedly`,
+          result.response
+        )
+      } else if (result.validationStatus === "invalid-response") {
+        log.error(
+          `Response from ${apiName} API endpoint ${result.requestContext.endpointName} does not match the expected schema`,
+          result.response
+        )
+      }
+      throw new APIValidationError(result.validationStatus)
+    },
+    validationOptions,
+    log
+  )
+}

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,10 +1,6 @@
 import { logger } from "../logging"
 import { TiFAPIClientCreator } from "./APIClient"
-import {
-  APIValidationError,
-  validateAPICall,
-  validateAPIClientCall
-} from "./APIValidation"
+import { validateAPIClientCall } from "./APIValidation"
 import { TiFAPIClient } from "./TiFAPISchema"
 import { ClientExtensions, tifAPITransport } from "./Transport"
 import { jwtMiddleware } from "./TransportMiddleware"

--- a/api/TiFAPI.ts
+++ b/api/TiFAPI.ts
@@ -1,6 +1,10 @@
 import { logger } from "../logging"
 import { TiFAPIClientCreator } from "./APIClient"
-import { APIValidationError, validateAPICall } from "./APIValidation"
+import {
+  APIValidationError,
+  validateAPICall,
+  validateAPIClientCall
+} from "./APIValidation"
 import { TiFAPIClient } from "./TiFAPISchema"
 import { ClientExtensions, tifAPITransport } from "./Transport"
 import { jwtMiddleware } from "./TransportMiddleware"
@@ -9,31 +13,21 @@ export const TEST_API_URL = new URL("http://localhost:8080")
 
 const log = logger("tif.apiClient.validation")
 
-export const validateAPIClientCall = validateAPICall<ClientExtensions>(result => {
-  if (result.validationStatus === "passed") {
-    return result.response
-  } else if (result.validationStatus === "invalid-request") {
-    log.error(`Request to TiF API endpoint ${result.requestContext.endpointName} is not valid`, result.requestContext)
-  } else if (result.validationStatus === "unexpected-response") {
-    log.error(`TiF API endpoint ${result.requestContext.endpointName} responded unexpectedly`, result.response)
-  } else if (result.validationStatus === "invalid-response") {
-    log.error(`Response from TiF API endpoint ${result.requestContext.endpointName} does not match the expected schema`, result.response)
-  }
-  
-  throw new APIValidationError(result.validationStatus)
-})
+export const validateTiFAPIClientCall = validateAPIClientCall("TiF", log)
 
 type _StaticTiFAPI = typeof _TiFAPIClass
 export interface TiFAPIConstructor extends _StaticTiFAPI {}
 
-export interface TiFAPI extends InstanceType<TiFAPIConstructor>, TiFAPIClient<ClientExtensions> {}
+export interface TiFAPI
+  extends InstanceType<TiFAPIConstructor>,
+    TiFAPIClient<ClientExtensions> {}
 
 class _TiFAPIClass {
   /**
    * An instance of {@link TiFAPIClient} for unit testing.
    */
   static testAuthenticatedInstance = TiFAPIClientCreator<ClientExtensions>(
-    validateAPIClientCall,
+    validateTiFAPIClientCall,
     jwtMiddleware(
       async () => "I was here at the beginning, and I will proclaim the end."
     ),
@@ -44,7 +38,7 @@ class _TiFAPIClass {
    * An instance of {@link TiFAPIClient} for unit testing.
    */
   static testUnauthenticatedInstance = TiFAPIClientCreator<ClientExtensions>(
-    validateAPIClientCall,
+    validateTiFAPIClientCall,
     tifAPITransport(TEST_API_URL)
   )
 }

--- a/api/Transport.ts
+++ b/api/Transport.ts
@@ -39,6 +39,7 @@ export const tifAPITransport = (baseURL: URL) => {
  * API Middleware that fetches data from a given url for clients of an HTTP API.
  *
  * @param baseURL the base url of the api to use.
+ * @param log A custom {@link Logger} to use.
  * @returns API Middleware to construct an instance of an API client.
  */
 export const apiTransport = (

--- a/api/Transport.ts
+++ b/api/Transport.ts
@@ -1,70 +1,100 @@
 import { urlString } from "../lib/URL"
-import { logger } from "../logging"
+import { Logger, logger } from "../logging"
 import { APIHandler, StatusCodes } from "./TransportTypes"
 
-export function resp<StatusCode extends StatusCodes, const T extends object>(status: StatusCode, data: T): { status: StatusCode, data: T };
-export function resp<StatusCode extends StatusCodes>(status: StatusCode): { status: StatusCode, data?: undefined };
-export function resp<StatusCode extends StatusCodes, const T extends object>(status: StatusCode, data?: T) {
-  return ({
+export function resp<StatusCode extends StatusCodes, const T extends object>(
+  status: StatusCode,
+  data: T
+): { status: StatusCode; data: T }
+export function resp<StatusCode extends StatusCodes>(
+  status: StatusCode
+): { status: StatusCode; data?: undefined }
+export function resp<StatusCode extends StatusCodes, const T extends object>(
+  status: StatusCode,
+  data?: T
+) {
+  return {
     status,
     data
-  })
+  }
 }
 
 const NoContentStatusCode = 204
 
 const log = logger("tif.api.client")
 
-export type ClientExtensions = {signal?: AbortSignal, headers?: HeadersInit}
+export type ClientExtensions = { signal?: AbortSignal; headers?: HeadersInit }
 
 /**
  * TiFAPIMiddleware that fetches data from a given url for clients of TiFAPI.
  *
  * @param baseURL the base url of the backend to use.
- * @param middleware a function to modify the fetch call.
  * @returns TiFAPIMiddleware to construct an instance of a TiFAPIClient.
  */
-export const tifAPITransport = (baseURL: URL): APIHandler<ClientExtensions> =>
-  async ({headers, endpointName, endpointSchema: {httpRequest: { endpoint, method } }, body, query, params, signal}) => 
-    {
-      try {
-        const resp = await fetch(
-          urlString({baseURL, endpoint, params, query}), 
-          {
-            method,
-            headers: {"Content-Type": "application/json", ...headers},
-            body: body ? JSON.stringify(body) : undefined,
-            signal
-          }
+export const tifAPITransport = (baseURL: URL) => {
+  return apiTransport(baseURL, log)
+}
+
+/**
+ * API Middleware that fetches data from a given url for clients of an HTTP API.
+ *
+ * @param baseURL the base url of the api to use.
+ * @returns API Middleware to construct an instance of an API client.
+ */
+export const apiTransport = (
+  baseURL: URL,
+  log: Logger
+): APIHandler<ClientExtensions> => {
+  return async ({
+    headers,
+    endpointName,
+    endpointSchema: {
+      httpRequest: { endpoint, method }
+    },
+    body,
+    query,
+    params,
+    signal
+  }) => {
+    try {
+      const resp = await fetch(
+        urlString({ baseURL, endpoint, params, query }),
+        {
+          method,
+          headers: { "Content-Type": "application/json", ...headers },
+          body: body ? JSON.stringify(body) : undefined,
+          signal
+        }
+      )
+
+      const data = await tryResponseBody(resp)
+
+      if (data && resp.status === NoContentStatusCode) {
+        throw new Error(
+          `TiFAPI responded with a 204 status code and body ${JSON.stringify(data)}. A 204 status code should not produce a body.`
         )
-
-        const data = await tryResponseBody(resp)
-        
-        if (data && resp.status === NoContentStatusCode) {
-          throw new Error(
-            `TiFAPI responded with a 204 status code and body ${JSON.stringify(data)}. A 204 status code should not produce a body.`
-          )
-        }
-
-        return {
-          // NB: typescript doesn't properly expect the union of status codes
-          status: resp.status as StatusCodes as any,
-          data,
-        }
-      } catch (error) {
-        if (!(error instanceof DOMException) || error.name !== "AbortError") {
-          log.error("Failed to make tif API request.", {
-            error,
-            errorMessage: error.message,
-            body,
-            query,
-            params,
-            endpointName
-          })
-        }
-        throw error
       }
+
+      return {
+        // NB: typescript doesn't properly expect the union of status codes
+        status: resp.status as StatusCodes as any,
+        data
+      }
+    } catch (error) {
+      if (!(error instanceof DOMException) || error.name !== "AbortError") {
+        log.error("Failed to make tif API request.", {
+          error,
+          errorMessage: error.message,
+          body,
+          query,
+          params,
+          endpointName
+        })
+      }
+      throw error
     }
+  }
+}
 
 const tryResponseBody = async (resp: Response) => {
   try {


### PR DESCRIPTION
Genericizes the API Transport and API Client Validation middlewares to allow custom loggers and names to be passed such that we aren't stuck the TiF name when working with other APIs.

## Tickets

https://trello.com/c/tF0FfaJ6