### PR TITLE
result type fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
               
       - name: Run linter
         run: |
-          npx tsc --noEmit
+          npm run lint
 
       - name: Run tests
         run: |

--- a/api/APIClient.test.ts
+++ b/api/APIClient.test.ts
@@ -14,7 +14,7 @@ const mockAPI = <T extends APISchema>(
   endpointSchema: T,
   expectedRequest?: any,
   mockResponse?: any,
-  handler?: any
+  handler?: (_: any) => void
 ) => {
   mockAPIServer(new URL(TEST_BASE_URL), endpointSchema, {
     checkUser: { expectedRequest, mockResponse, handler }

--- a/domain-models/User.test.ts
+++ b/domain-models/User.test.ts
@@ -45,7 +45,6 @@ describe("User tests", () => {
         "Hello @user @hello, make sure@interlinked names aren't parsed. Also the name has to be @valid(#*&$. @*($&) @world Now for a @superduperlongname"
       const matches = linkify
         .match(str)
-        //@ts-expect-error extends Match
         ?.map((m: UserHandleLinkifyMatch) => m.userHandle.toString())
       expect(matches).toEqual([
         "@user",

--- a/lib/Result.test.ts
+++ b/lib/Result.test.ts
@@ -1,4 +1,4 @@
-import { failure, promiseResult, success } from "./Result"
+import { ExtractFailure, ExtractSuccess, failure, promiseResult, success } from "./Result"
 
 describe("Result tests", () => {
   const successResult = { status: "success", value: "passed" } as const
@@ -44,25 +44,40 @@ describe("Result tests", () => {
   })
 
   it("should allow success results to be transformed", () => {
-    const currentSuccess = success("passed" as const)
-    expect(currentSuccess.withSuccess("newSuccess" as const)).toMatchObject({
+    const currentSuccess = success("passed" as const);
+    const newSuccess = currentSuccess.withSuccess("newSuccess" as const)
+
+    expect(newSuccess).toMatchObject({
       status: "success",
       value: "newSuccess"
-    })
-    expect(
-      currentSuccess.mapSuccess(() => "mappedSuccess" as const)
-    ).toMatchObject({
+    });
+    
+    const assertTransformedSuccess: ExtractSuccess<typeof newSuccess> = "newSuccess";
+
+    const mappedSuccess = currentSuccess.mapSuccess(() => "mappedSuccess" as const);
+    expect(mappedSuccess).toMatchObject({
       status: "success",
       value: "mappedSuccess"
-    })
-    expect(
-      currentSuccess.flatMapSuccess(() => failure("failed" as const))
-    ).toMatchObject(failureResult)
-    expect(currentSuccess.inverted()).toMatchObject({
+    });
+
+    const assertMappedSuccess: ExtractSuccess<typeof mappedSuccess> = "mappedSuccess";
+
+    const failureResult = currentSuccess.flatMapSuccess(() => failure("failed" as const));
+    expect(failureResult).toMatchObject({
+      status: "failure",
+      value: "failed"
+    });
+
+    const assertFailureValue: ExtractFailure<typeof failureResult> = "failed";
+
+    const invertedResult = currentSuccess.inverted();
+    expect(invertedResult).toMatchObject({
       status: "failure" as const,
       value: "passed" as const
-    })
-  })
+    });
+
+    const assertInvertedValue: ExtractFailure<typeof invertedResult> = "passedf";
+  });
 
   it("should not modify success result with failures", () => {
     expect(

--- a/lib/Result.ts
+++ b/lib/Result.ts
@@ -71,16 +71,14 @@ export class SuccessResult<Success, Failure> {
   ): AwaitableResult<Success, NewFailure | Failure> {
     return handler(this.value).withSuccess(this.value)
   }
-
+  
   /**
    * Runs the handler with the current failure value and passes the current failure value through
    * if the handler is successful.
    *
    * @param handler a function to process the current failure value and either passthrough the value or return a failure.
    */
-  passthroughFailure<NewSuccess, NewFailure>(
-    _: (value: Failure) => AwaitableResult<NewSuccess, NewFailure>
-  ) {
+  passthroughFailure<NewSuccess, NewFailure>(_: (value: Failure) => AwaitableResult<NewSuccess, NewFailure>) {
     return this as unknown as AwaitableResult<Success, NewFailure | Failure>
   }
 
@@ -143,7 +141,7 @@ export class SuccessResult<Success, Failure> {
   inverted() {
     return failure(this.value) as FailureResult<Failure, Success>
   }
-
+  
   /**
    * Returns the result value.
    */
@@ -192,19 +190,17 @@ export class FailureResult<Success, Failure> {
     this.observe(handler)
     return this
   }
-
+  
   /**
    * Runs the handler with the current success value and passes the current success value through
    * if the handler is successful.
    *
    * @param handler a function to process the current success value and either passthrough the value or return a failure.
    */
-  passthroughSuccess<NewSuccess, NewFailure>(
-    _: (value: Success) => AwaitableResult<NewSuccess, NewFailure>
-  ) {
+  passthroughSuccess<NewSuccess, NewFailure>(_: (value: Success) => AwaitableResult<NewSuccess, NewFailure>) {
     return this as unknown as AwaitableResult<Success, NewFailure | Failure>
   }
-
+  
   /**
    * Runs the handler with the current failure value and passes the current failure value through
    * if the handler is successful.
@@ -275,7 +271,7 @@ export class FailureResult<Success, Failure> {
   inverted() {
     return success(this.value) as SuccessResult<Failure, Success>
   }
-
+  
   /**
    * Returns the result value.
    */
@@ -328,7 +324,7 @@ export class PromiseResult<Success, Failure> extends Promise<
     this.then((result) => result.observeFailure(handler))
     return this
   }
-
+  
   /**
    * Runs the handler with the current success value and passes the current success value through
    * if the handler is successful.
@@ -338,7 +334,7 @@ export class PromiseResult<Success, Failure> extends Promise<
   passthroughSuccess<NewSuccess, NewFailure>(
     handler: (value: Success) => AwaitableResult<NewSuccess, NewFailure>
   ): AwaitableResult<Success, Failure | NewFailure> {
-    return this.then((result) => result.passthroughSuccess(handler))
+    return promiseResult(this.then((result) => result.passthroughSuccess(handler)))
   }
 
   /**
@@ -350,9 +346,7 @@ export class PromiseResult<Success, Failure> extends Promise<
   passthroughFailure<NewSuccess, NewFailure>(
     handler: (value: Failure) => AwaitableResult<NewSuccess, NewFailure>
   ): AwaitableResult<NewSuccess, Failure | NewFailure> {
-    return this.then((result) =>
-      result.passthroughFailure(handler)
-    ) as PromiseResult
+    return promiseResult(this.then((result) => result.passthroughFailure(handler)))
   }
 
   /**
@@ -363,7 +357,7 @@ export class PromiseResult<Success, Failure> extends Promise<
   flatMapSuccess<NewSuccess, NewFailure>(
     mapper: (value: Success) => AwaitableResult<NewSuccess, NewFailure>
   ): PromiseResult<NewSuccess, Failure | NewFailure> {
-    return this.then((result) => result.flatMapSuccess(mapper))
+    return promiseResult(this.then((result) => result.flatMapSuccess(mapper)))
   }
 
   /**
@@ -373,53 +367,45 @@ export class PromiseResult<Success, Failure> extends Promise<
    */
   flatMapFailure<NewSuccess, NewFailure>(
     mapper: (value: Failure) => AwaitableResult<NewSuccess, NewFailure>
-  ): PromiseResult<NewSuccess | Success, NewFailre> {
-    return this.then((result) => result.flatMapFailure(mapper))
+  ) {
+    return promiseResult(this.then((result) => result.flatMapFailure(mapper)))
   }
 
   /**
    * Transforms the success value into a new one lazily.
    */
-  mapSuccess<NewSuccess>(
-    mapper: (value: Success) => NewSuccess
-  ): PromiseResult<Success, NewFailre | Failure> {
-    return this.then((result) => result.mapSuccess(mapper))
+  mapSuccess<NewSuccess>(mapper: (value: Success) => NewSuccess) {
+    return promiseResult(this.then((result) => result.mapSuccess(mapper)))
   }
 
   /**
    * Transforms the failure value into a new one lazily.
    */
-  mapFailure<NewFailure>(
-    mapper: (value: Failure) => NewFailure
-  ): PromiseResult<Success, NewFailre> {
-    return this.then((result) => result.mapFailure(mapper))
+  mapFailure<NewFailure>(mapper: (value: Failure) => NewFailure) {
+    return promiseResult(this.then((result) => result.mapFailure(mapper)))
   }
 
   /**
    * If this result is successful, inverts this result into an unsuccessful one and vice-versa.
    */
-  inverted(): PromiseResult<Failure, Success> {
-    return this.then((res) => res.inverted())
+  inverted() {
+    return promiseResult(this.then((res) => res.inverted()))
   }
 
   /**
    * Sets the failure value to the given value eagerly.
    */
-  withFailure<NewFailure>(
-    value: NewFailure
-  ): PromiseResult<Success, NewFailure> {
-    return this.then((result) => result.withFailure(value))
+  withFailure<NewFailure>(value: NewFailure) {
+    return promiseResult(this.then((result) => result.withFailure(value)))
   }
 
   /**
    * Sets the success value to the given value eagerly.
    */
-  withSuccess<NewSuccess>(
-    value: NewSuccess
-  ): PromiseResult<NewSuccess, Failure> {
-    return this.then((result) => result.withSuccess(value))
+  withSuccess<NewSuccess>(value: NewSuccess) {
+    return promiseResult(this.then((result) => result.withSuccess(value)))
   }
-
+  
   /**
    * Returns the result value.
    */
@@ -435,35 +421,36 @@ export const promiseResult = <Success, Failure>(
   promise: Promise<Result<Success, Failure>> | Result<Success, Failure>
 ): PromiseResult<Success, Failure> => {
   if (promise instanceof PromiseResult) {
-    return promise
+    return promise;
   }
   if (promise instanceof Promise) {
-    Object.setPrototypeOf(promise, PromiseResult.prototype)
-    return promise
+    Object.setPrototypeOf(promise, PromiseResult.prototype);
+    return promise as PromiseResult<Success, Failure>;
   }
-  return PromiseResult.resolve(promise)
-}
+
+  return new PromiseResult<Success, Failure>((resolve) => {
+    resolve(promise);
+  });
+};
 
 /**
  * Extracts the success value of a given result. Ex.
- *
+ * 
  * ```ts
  * const getUser = (user: {name: string, id: number}) =>
  *  success(user)
  *    .mapSuccess(({ name, id }) => ({ name, id, newField: `${name}${id}` }))
- *
+ * 
  * type transformedUserType = ExtractSuccess<ReturnType<typeof getUser>>
  * //transformedUserType is derived as {name: string, id: number, newField: string}
  * ```
  */
-export type ExtractSuccess<T> =
-  T extends AwaitableResult<infer U, any> ? U : never
+export type ExtractSuccess<T> = T extends AwaitableResult<infer U, any> ? U : never;
 
 /**
  * Extracts the failure value of a given result. See {@link ExtractSuccess}
  */
-export type ExtractFailure<T> =
-  T extends AwaitableResult<any, infer U> ? U : never
+export type ExtractFailure<T> = T extends AwaitableResult<any, infer U> ? U : never;
 
 /**
  * Creates a {@link SuccessResult} with the given value.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lintapispecs": "npx lint-openapi specs.json",
     "genapispecs": "npx ts-node --transpile-only npm-scripts/generateApiSpecs",
+    "lint": "npx tsc -p tsconfig.test.json",
     "test": "jest --collectCoverage",
     "test:ci": "jest --ci --collectCoverage",
     "prepare": "node --loader ts-node/esm npm-scripts/prepare.ts",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "outDir": ".",
+    "jsx": "react-native",
+    "baseUrl": ".",
+    "module": "commonjs",
+    "target": "esnext",
+    "lib": ["dom", "esnext"],
+    "checkJs": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "noImplicitAny": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strictNullChecks": true
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.test.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "npm-scripts",
+    "jest",
+    "coverage",
+  ]
+}


### PR DESCRIPTION
This pr fixes some typos in Result.ts and re-enables type checking and adds type assertions to Result.test.ts to prevent typescript regressions.

Fix result.ts errors
Add type assertions to the test file
Remove ts-nocheck on result.ts

TASK_UNTRACKED