### PR TITLE
`DatabaseValue`

### DIFF
--- a/domain-models/ColorString.ts
+++ b/domain-models/ColorString.ts
@@ -1,4 +1,4 @@
-import { DatabaseValue, DatabaseValueConvertible } from "lib/Database"
+import { DatabaseValueConvertible } from "../lib/Database"
 import { colorWithOpacity } from "../lib/Color"
 import { z } from "zod"
 

--- a/domain-models/ColorString.ts
+++ b/domain-models/ColorString.ts
@@ -1,10 +1,11 @@
+import { DatabaseValue, DatabaseValueConvertible } from "lib/Database"
 import { colorWithOpacity } from "../lib/Color"
 import { z } from "zod"
 
 /**
  * An easy way to manipulate characteristics of color strings (Alpha, RGB, etc.).
  */
-export class ColorString {
+export class ColorString implements DatabaseValueConvertible {
   private readonly rgbHexString: string
   readonly opacity: number
 
@@ -30,6 +31,10 @@ export class ColorString {
   }
 
   toJSON() {
+    return this.toString()
+  }
+
+  toDatabaseValue() {
     return this.toString()
   }
 

--- a/domain-models/User.ts
+++ b/domain-models/User.ts
@@ -5,7 +5,7 @@ import {
   linkify
 } from "../lib/LinkifyIt"
 import { Tagged } from "../lib/Types/HelperTypes"
-import { DatabaseValueConvertible } from "lib/Database"
+import { DatabaseValueConvertible } from "../lib/Database"
 
 export type UserID = Tagged<string, "userId">
 

--- a/lib/Database.ts
+++ b/lib/Database.ts
@@ -1,0 +1,14 @@
+/**
+ * A value that can be inserted into the database.
+ */
+export type DatabaseValue = undefined | number | string
+
+/**
+ * An interface for converting rich types into database insertable values.
+ */
+export interface DatabaseValueConvertible {
+  /**
+   * Returns an {@link DatabaseValue} for instance.
+   */
+  toDatabaseValue(): DatabaseValue
+}


### PR DESCRIPTION
To interpolate classes into SQL queries on the backend, we were using a weird if statement mapping that checked if a value was either `ColorString` or `UserHandle`. To ensure that we don't forget to add other cases of rich value classes to that if statement, we can use a simple `DatabaseValueConvertible` interface.

TASK_UNTRACKED