### PR TITLE
Increase `EventEditSchema` Invalid Date Buffer

### DIFF
--- a/domain-models/Event.ts
+++ b/domain-models/Event.ts
@@ -246,7 +246,7 @@ export const EventEditSchema = z.object({
   description: EventDescriptionSchema,
   startDateTime: z.coerce
     .date()
-    .refine((date) => date >= new Date().ext.addSeconds(-10)),
+    .refine((date) => date >= new Date().ext.add(-1, "days")),
   duration: z.number().min(60),
   shouldHideAfterStartDate: z.boolean(),
   location: EventEditLocationSchema


### PR DESCRIPTION
Increases it from 10 seconds to 1 day, this fixes a really annoying validation bug on the frontend, where the user would only have 10 seconds to create an event before it becomes invalid.

TASK_UNTRACKED