### PR TITLE
Address formatting - return undefined for unknown addresses

### DIFF
--- a/lib/AddressFormatting.ts
+++ b/lib/AddressFormatting.ts
@@ -36,7 +36,7 @@ export const placemarkToFormattedAddress = (placemark: Placemark) => {
  */
 export const placemarkToAbbreviatedAddress = (placemark: Placemark) => {
   if (placemark.city === undefined || placemark.region === undefined) {
-    return "Unknown Location"
+    return undefined
   } else if (placemark.name === undefined) {
     return `${placemark.city}, ${placemark.region}`
   }


### PR DESCRIPTION
AWS maps the location name "Unknown Location" to this Arkansas place
![image](https://github.com/user-attachments/assets/151d5609-6ea8-473d-ba6a-8823fd62c8c6)
We should instead make it return undefined and format it on the front end.

https://github.com/tifapp/FitnessProjectBackend/pull/299

TASK_UNTRACKED