### PR TITLE
Request Logging Middleware

### DIFF
--- a/api/TransportMiddleware.test.ts
+++ b/api/TransportMiddleware.test.ts
@@ -1,5 +1,6 @@
+import { addLogHandler, consoleLogHandler, resetLogHandlers } from "../logging"
 import { ClientExtensions } from "./Transport"
-import { jwtMiddleware } from "./TransportMiddleware"
+import { jwtMiddleware, requestLoggingMiddleware } from "./TransportMiddleware"
 import { TiFAPIInputContext } from "./TransportTypes"
 
 describe("TiFAPITransportMiddlewareTests", () => {
@@ -9,7 +10,10 @@ describe("TiFAPITransportMiddlewareTests", () => {
     it("should include a bearer token in the request headers with the jwt", async () => {
       const middleware = jwtMiddleware(async () => TEST_JWT)
       const next = jest.fn()
-      await middleware({ headers: {} } as TiFAPIInputContext<ClientExtensions>, next)
+      await middleware(
+        { headers: {} } as TiFAPIInputContext<ClientExtensions>,
+        next
+      )
       expect(next).toHaveBeenCalledWith(
         expect.objectContaining({
           headers: { Authorization: `Bearer ${TEST_JWT}` }
@@ -20,10 +24,38 @@ describe("TiFAPITransportMiddlewareTests", () => {
     it("should omit the bearer token in the request headers when no jwt", async () => {
       const middleware = jwtMiddleware(async () => undefined)
       const next = jest.fn()
-      await middleware({ headers: {} } as TiFAPIInputContext<ClientExtensions>, next)
+      await middleware(
+        { headers: {} } as TiFAPIInputContext<ClientExtensions>,
+        next
+      )
       expect(next).toHaveBeenCalledWith(
         expect.objectContaining({ headers: {} })
       )
+    })
+  })
+
+  describe("LoggingMiddleware tests", () => {
+    test("logs a request", async () => {
+      const testHandler = jest.fn()
+      addLogHandler(consoleLogHandler())
+      addLogHandler(testHandler)
+      const middleware = requestLoggingMiddleware("test", "info")
+      const next = jest.fn()
+      await middleware(
+        {
+          headers: {},
+          endpointName: "/test",
+          endpointSchema: {
+            httpRequest: {
+              method: "POST"
+            }
+          }
+        } as TiFAPIInputContext<ClientExtensions>,
+        next
+      )
+      expect(testHandler).toHaveBeenCalledTimes(1)
+      expect(next).toHaveBeenCalledTimes(1)
+      resetLogHandlers()
     })
   })
 })

--- a/api/TransportMiddleware.ts
+++ b/api/TransportMiddleware.ts
@@ -1,5 +1,7 @@
+import { LogLevel, logger } from "../logging"
 import { ClientExtensions } from "./Transport"
 import { APIMiddleware } from "./TransportTypes"
+import { URLEndpoint, urlString } from "../lib/URL"
 
 /**
  * Transport middleware that adds a JWT bearer token to the outgoing request.
@@ -14,5 +16,29 @@ export const jwtMiddleware = (
       ...request,
       headers: { ...request.headers, Authorization: `Bearer ${token}` }
     })
+  }
+}
+
+/**
+ * A middleware for request logging.
+ *
+ * @param apiName The name of the API to log requests for.
+ * @param level The log level to log requests at. Defaults to `"trace"`.
+ */
+export const requestLoggingMiddleware = (
+  apiName: string,
+  level: LogLevel = "trace"
+): APIMiddleware<ClientExtensions> => {
+  const log = logger(`${apiName}.api.requests`)
+  return async (request, next) => {
+    const method = request.endpointSchema.httpRequest.method
+    const path = urlString({
+      endpoint: request.endpointName as URLEndpoint,
+      params: request.params,
+      query: request.query
+    })
+    const metadata = request.body ? { body: request.body } : undefined
+    log[level](`Sending ${method} request to path ${path}.`, metadata)
+    return await next(request)
   }
 }


### PR DESCRIPTION
Adds an `APIMiddleware` that logs requests that the client sends. It does not include the base URL, but I think having the `apiName` should suffice for that.

TASK_UNTRACKED