### PR TITLE
Add Response Logging + Fix Request Logging

### DIFF
--- a/api/Transport.ts
+++ b/api/Transport.ts
@@ -59,11 +59,13 @@ export const apiTransport = (
     signal
   }) => {
     try {
+      const headerValues = new Headers(headers)
+      headerValues.set("Content-Type", "application/json")
       const resp = await fetch(
         urlString({ baseURL, endpoint, params, query }),
         {
           method,
-          headers: { "Content-Type": "application/json", ...headers },
+          headers: headerValues,
           body: body ? JSON.stringify(body) : undefined,
           signal
         }

--- a/api/TransportMiddleware.test.ts
+++ b/api/TransportMiddleware.test.ts
@@ -1,7 +1,16 @@
-import { addLogHandler, consoleLogHandler, resetLogHandlers } from "../logging"
-import { ClientExtensions } from "./Transport"
+import {
+  addLogHandler,
+  consoleLogHandler,
+  logger,
+  resetLogHandlers
+} from "../logging"
+import { mockAPIServer } from "../test-helpers/mockAPIServer"
+import { APIClientCreator } from "./APIClient"
+import { DEFAULT_LOG } from "./APIValidation"
+import { ClientExtensions, apiTransport } from "./Transport"
 import { jwtMiddleware, requestLoggingMiddleware } from "./TransportMiddleware"
-import { TiFAPIInputContext } from "./TransportTypes"
+import { TiFAPIInputContext, endpointSchema } from "./TransportTypes"
+import { z } from "zod"
 
 describe("TiFAPITransportMiddlewareTests", () => {
   describe("JWTMiddleware tests", () => {
@@ -35,27 +44,61 @@ describe("TiFAPITransportMiddlewareTests", () => {
   })
 
   describe("LoggingMiddleware tests", () => {
+    afterEach(() => resetLogHandlers())
+
     test("logs a request", async () => {
       const testHandler = jest.fn()
       addLogHandler(consoleLogHandler())
       addLogHandler(testHandler)
-      const middleware = requestLoggingMiddleware("test", "info")
-      const next = jest.fn()
-      await middleware(
-        {
-          headers: {},
-          endpointName: "/test",
-          endpointSchema: {
-            httpRequest: {
-              method: "POST"
-            }
+      const schema = {
+        test: endpointSchema({
+          input: {
+            query: z.object({ isFiltered: z.boolean() }),
+            params: z.object({ id: z.number() }),
+            body: z.object({ name: z.string() })
+          },
+          outputs: {
+            status200: z.object({ isOk: z.boolean() })
+          },
+          httpRequest: {
+            endpoint: "/test/:id",
+            method: "POST"
           }
-        } as TiFAPIInputContext<ClientExtensions>,
-        next
+        })
+      }
+      const url = new URL("https://test.api")
+      const client = APIClientCreator(
+        schema,
+        requestLoggingMiddleware("test", "info"),
+        apiTransport("test", url, logger("test.request.logging.api.transport"))
       )
-      expect(testHandler).toHaveBeenCalledTimes(1)
-      expect(next).toHaveBeenCalledTimes(1)
-      resetLogHandlers()
+      mockAPIServer(url, schema, {
+        test: { mockResponse: { status: 200, data: { isOk: true } } }
+      })
+      await client.test({
+        query: { isFiltered: true },
+        params: { id: 20 },
+        body: { name: "blob" }
+      })
+
+      expect(testHandler).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        "info",
+        "Sending POST request to path /test/20?isFiltered=true.",
+        { body: { name: "blob" }, requestId: expect.any(String) }
+      )
+      expect(testHandler).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        "info",
+        "Received 200 response from path /test/20?isFiltered=true.",
+        {
+          body: { isOk: true },
+          requestId: expect.any(String)
+        }
+      )
+      expect(testHandler).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/api/TransportMiddleware.ts
+++ b/api/TransportMiddleware.ts
@@ -2,6 +2,7 @@ import { LogLevel, logger } from "../logging"
 import { ClientExtensions } from "./Transport"
 import { APIMiddleware } from "./TransportTypes"
 import { URLEndpoint, urlString } from "../lib/URL"
+import { uuidString } from "../lib/UUID"
 
 /**
  * Transport middleware that adds a JWT bearer token to the outgoing request.
@@ -31,14 +32,22 @@ export const requestLoggingMiddleware = (
 ): APIMiddleware<ClientExtensions> => {
   const log = logger(`${apiName}.api.requests`)
   return async (request, next) => {
+    const requestId = uuidString()
     const method = request.endpointSchema.httpRequest.method
     const path = urlString({
-      endpoint: request.endpointName as URLEndpoint,
+      endpoint: request.endpointSchema.httpRequest.endpoint,
       params: request.params,
       query: request.query
     })
-    const metadata = request.body ? { body: request.body } : undefined
-    log[level](`Sending ${method} request to path ${path}.`, metadata)
-    return await next(request)
+    log[level](`Sending ${method} request to path ${path}.`, {
+      body: request.body,
+      requestId
+    })
+    const resp = await next(request)
+    log[level](`Received ${resp.status} response from path ${path}.`, {
+      body: resp.data,
+      requestId
+    })
+    return resp
   }
 }

--- a/lib/UUID.ts
+++ b/lib/UUID.ts
@@ -1,0 +1,21 @@
+const mathRandomUUID = () => {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+    const random = (Math.random() * 16) | 0
+    const value = char === "x" ? random : (random & 0x3) | 0x8
+    return value.toString(16)
+  })
+}
+
+/**
+ * A function to generate a uuid v4 string.
+ *
+ * If node's crypto module is available, then it is used, otherwise a Math.random implementation is
+ * used. Therefore, this should not be used for purposes of security.
+ */
+export const uuidString = (() => {
+  try {
+    return require("crypto").randomUUID as () => string
+  } catch {
+    return mathRandomUUID
+  }
+})()

--- a/test-helpers/mockAPIServer.ts
+++ b/test-helpers/mockAPIServer.ts
@@ -1,84 +1,130 @@
-import { HttpResponse, http } from "msw";
-import { TEST_API_URL, TiFAPI, TiFAPIClient, TiFAPISchema } from "../api";
-import { APIHandler, APIResponseSchemas, APISchema, EndpointSchemasToFunctions, GenericEndpointSchema, HTTPMethod, InputSchema, StatusCodes } from "../api/TransportTypes";
-import { queryFromSearchParams } from "../lib/URL";
-import { mswServer } from "./MSW";
+import { HttpResponse, http } from "msw"
+import { TEST_API_URL, TiFAPI, TiFAPIClient, TiFAPISchema } from "../api"
+import {
+  APIHandler,
+  APIResponseSchemas,
+  APISchema,
+  EndpointSchemasToFunctions,
+  GenericEndpointSchema,
+  HTTPMethod,
+  InputSchema,
+  StatusCodes
+} from "../api/TransportTypes"
+import { queryFromSearchParams } from "../lib/URL"
+import { mswServer } from "./MSW"
 
-export const mockEndpointSchema = (method: HTTPMethod, input?: InputSchema, outputs?: APIResponseSchemas) => ({
-  checkUser: {
-    input,
-    outputs,
-    httpRequest: {
-      method,
-      endpoint: "/_"
+export const mockEndpointSchema = (
+  method: HTTPMethod,
+  input?: InputSchema,
+  outputs?: APIResponseSchemas
+) =>
+  ({
+    checkUser: {
+      input,
+      outputs,
+      httpRequest: {
+        method,
+        endpoint: "/_"
+      }
     }
-  }
-}) as APISchema
+  }) as APISchema
 
-const mswBuilder = (testUrl: URL, endpointName: string, endpointSchema: GenericEndpointSchema, {expectedRequest, handler, mockResponse}: MockAPIImplementation<APIHandler>) => {
-  const {httpRequest: {method, endpoint}} = endpointSchema
+const mswBuilder = (
+  testUrl: URL,
+  endpointName: string,
+  endpointSchema: GenericEndpointSchema,
+  { expectedRequest, handler, mockResponse }: MockAPIImplementation<APIHandler>
+) => {
+  const {
+    httpRequest: { method, endpoint }
+  } = endpointSchema
 
   mswServer.use(
-    http[method.toLowerCase() as Lowercase<typeof method>](`${testUrl}${endpoint.slice(1)}`, async ({ request, params }) => {
-      let body: any
-      if (method === "GET") {
-        body = undefined
-      } else {
-        try {
-          body = await request.json();
-        } catch {
-          body = undefined;
+    http[method.toLowerCase() as Lowercase<typeof method>](
+      `${testUrl}${endpoint.slice(1)}`,
+      async ({ request, params }) => {
+        let body: any
+        if (method === "GET") {
+          body = undefined
+        } else {
+          try {
+            body = await request.json()
+          } catch {
+            body = undefined
+          }
         }
+
+        const input = {
+          body,
+          params,
+          query: queryFromSearchParams(new URL(request.url)),
+          headers: request.headers
+        }
+
+        if (expectedRequest) {
+          expect(input).toMatchObject(expectedRequest)
+        }
+
+        handler?.({ ...input, endpointName, endpointSchema })
+
+        const { data, status } = mockResponse
+
+        return HttpResponse.json(data, { status })
       }
-
-      const input = {body, params, query: queryFromSearchParams(new URL(request.url))}
-    
-      if (expectedRequest) {
-        expect(input).toMatchObject(expectedRequest)
-      }
-
-      handler?.({...input, endpointName, endpointSchema})
-
-      const {data, status} = mockResponse
-
-      return HttpResponse.json(data, { status })
-    })
-  );
+    )
+  )
 }
 
 type StringURLParams<T extends { query: any; path: any }> = {
-  [K in keyof T]: K extends 'query' | 'path' ? StringFields<T[K]> : T[K];
-};
+  [K in keyof T]: K extends "query" | "path" ? StringFields<T[K]> : T[K]
+}
 
 type StringFields<T> = {
-  [K in keyof T]: string;
-};
+  [K in keyof T]: string
+}
 
 export type MockAPIImplementation<Fn extends (...args: any) => any> = {
-  expectedRequest?: StringURLParams<Parameters<Fn>[0]>,
-  handler?: (args: Parameters<Fn>[0]) => void,
-  mockResponse: Awaited<ReturnType<Fn>>,
+  expectedRequest?: StringURLParams<Parameters<Fn>[0]>
+  handler?: (args: Parameters<Fn>[0]) => void
+  mockResponse: Awaited<ReturnType<Fn>>
 }
 
 export const mockAPIServer = <T extends APISchema>(
   testUrl: URL,
   endpointSchema: T,
   endpointMocks: Partial<{
-    [EndpointName in keyof EndpointSchemasToFunctions<T>]: MockAPIImplementation<EndpointSchemasToFunctions<T>[EndpointName]>
+    [EndpointName in keyof EndpointSchemasToFunctions<T>]: MockAPIImplementation<
+      EndpointSchemasToFunctions<T>[EndpointName]
+    >
   }>
-) => 
+) =>
   Object.entries(endpointMocks).forEach(([endpointName, endpointMock]) =>
-    mswBuilder(testUrl, endpointName, endpointSchema[endpointName], endpointMock)
+    mswBuilder(
+      testUrl,
+      endpointName,
+      endpointSchema[endpointName],
+      endpointMock
+    )
   )
 
 export const mockTiFServer = (
   endpointMocks: Partial<{
-    [EndpointName in keyof TiFAPIClient]: MockAPIImplementation<TiFAPIClient[EndpointName]>
+    [EndpointName in keyof TiFAPIClient]: MockAPIImplementation<
+      TiFAPIClient[EndpointName]
+    >
   }>
+) => mockAPIServer(TEST_API_URL, TiFAPISchema, endpointMocks)
+
+type APIResponse<T, U extends StatusCodes> = T extends { status: U } ? T : never
+
+export const mockTiFEndpoint = <
+  EndpointName extends keyof TiFAPIClient,
+  Status extends StatusCodes
+>(
+  endpointName: EndpointName,
+  status: Status,
+  data?: APIResponse<Awaited<ReturnType<TiFAPI[EndpointName]>>, Status>["data"]
 ) =>
-  mockAPIServer(TEST_API_URL, TiFAPISchema, endpointMocks)
-
-type APIResponse<T, U extends StatusCodes> = T extends { status: U } ? T : never;
-
-export const mockTiFEndpoint = <EndpointName extends keyof TiFAPIClient, Status extends StatusCodes>(endpointName: EndpointName, status: Status, data?: APIResponse<Awaited<ReturnType<TiFAPI[EndpointName]>>, Status>["data"]) =>
-  mockAPIServer(TEST_API_URL, TiFAPISchema, {[endpointName]: {mockResponse: ({status, data})}} as any) // NB: typescript not inferring key name properly
+  mockAPIServer(TEST_API_URL, TiFAPISchema, {
+    [endpointName]: { mockResponse: { status, data } }
+  } as any) // NB: typescript not inferring key name properly


### PR DESCRIPTION
- Ensures the entire translated path is used for the request logging.
- Adds response logging.
- Tracks the request with a request id in the logging middleware (we could potentially add this to the client extensions and have be autogenerated on each request).
- Adds the `uuidString` utility from the frontend.

TASK_UNTRACKED