### PR TITLE
Add dateRange query parameter to upcomingEvents endpoint

### DIFF
--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -38,6 +38,7 @@ import {
   UserSettingsResponseSchema,
   userTiFAPIErrorSchema
 } from "./models/User"
+import { UpcomingEventsFixedDateRangeSchema } from "./models/FixedDateRange"
 
 export const TiFAPISchema = {
   /**
@@ -338,7 +339,8 @@ export const TiFAPISchema = {
     input: {
       query: z.object({
         userId: UserIDSchema,
-        maxSecondsToStart: z.coerce.number().optional()
+        maxSecondsToStart: z.coerce.number().optional(),
+        dateRange: UpcomingEventsFixedDateRangeSchema
       })
     },
     outputs: {

--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -340,7 +340,7 @@ export const TiFAPISchema = {
       query: z.object({
         userId: UserIDSchema,
         maxSecondsToStart: z.coerce.number().optional(),
-        dateRange: UpcomingEventsFixedDateRangeSchema
+        dateRange: UpcomingEventsFixedDateRangeSchema.optional()
       })
     },
     outputs: {

--- a/api/models/FixedDateRange.test.ts
+++ b/api/models/FixedDateRange.test.ts
@@ -1,57 +1,90 @@
 import { ZodError } from "zod"
 import { dateRange } from "../../domain-models/FixedDateRange"
-import { CreateFixedDateRangeSchema, FixedDateRangeSchema, MIN_EVENT_DURATION } from "./FixedDateRange"
+import {
+  CreateFixedDateRangeSchema,
+  FixedDateRangeSchema,
+  MIN_EVENT_DURATION,
+  UpcomingEventsFixedDateRangeSchema
+} from "./FixedDateRange"
 
 describe("FixedDateRangeSchema tests", () => {
   test("valid FixedDateRange", () => {
-    expect(FixedDateRangeSchema.parse({
-      startDateTime: "2023-02-25T00:19:00.00Z",
-      endDateTime: "2023-02-25T00:20:00.00Z"
-    })).toEqual(dateRange(
-      new Date("2023-02-25T00:19:00.00Z"),
-      new Date("2023-02-25T00:20:00.00Z")
-    ))
+    expect(
+      FixedDateRangeSchema.parse({
+        startDateTime: "2023-02-25T00:19:00.00Z",
+        endDateTime: "2023-02-25T00:20:00.00Z"
+      })
+    ).toEqual(
+      dateRange(
+        new Date("2023-02-25T00:19:00.00Z"),
+        new Date("2023-02-25T00:20:00.00Z")
+      )
+    )
   })
 
   test("invalid dates", () => {
-    expect(() => FixedDateRangeSchema.parse({
-      startDateTime: "iuahbxgwd7823823geg",
-      endDateTime: "2023-02-25T00:18:00.00Z"
-    })).toThrow("Invalid date")
-    
-    expect(() => FixedDateRangeSchema.parse({
-      startDateTime: "2023-02-25T00:18:00.00Z",
-      endDateTime: "899832ue982hdh"
-    })).toThrow("Invalid date")
+    expect(() =>
+      FixedDateRangeSchema.parse({
+        startDateTime: "iuahbxgwd7823823geg",
+        endDateTime: "2023-02-25T00:18:00.00Z"
+      })
+    ).toThrow("Invalid date")
+
+    expect(() =>
+      FixedDateRangeSchema.parse({
+        startDateTime: "2023-02-25T00:18:00.00Z",
+        endDateTime: "899832ue982hdh"
+      })
+    ).toThrow("Invalid date")
   })
-  
+
   test("start date before end date", () => {
-    expect(() => FixedDateRangeSchema.parse({
-      startDateTime: "2023-02-25T00:19:00.00Z",
-      endDateTime: "2023-02-25T00:18:00.00Z"
-    })).toThrow(`Start Date must be before End Date.`)
+    expect(() =>
+      FixedDateRangeSchema.parse({
+        startDateTime: "2023-02-25T00:19:00.00Z",
+        endDateTime: "2023-02-25T00:18:00.00Z"
+      })
+    ).toThrow(`Start Date must be before End Date.`)
+  })
+})
+
+describe("UpcomingEventsFixedDateRangeSchema tests", () => {
+  it("should parse a valid base64 URL encoded date range", () => {
+    const param =
+      "ew0KICAgICAgICAic3RhcnREYXRlVGltZSI6ICIyMDIzLTAyLTI1VDAwOjE5OjAwLjAwWiIsDQogICAgICAgICJlbmREYXRlVGltZSI6ICIyMDIzLTAyLTI1VDAwOjIwOjAwLjAwWiINCiAgICAgIH0"
+    expect(UpcomingEventsFixedDateRangeSchema.parse(param)).toEqual(
+      dateRange(
+        new Date("2023-02-25T00:19:00.00Z"),
+        new Date("2023-02-25T00:20:00.00Z")
+      )
+    )
+  })
+
+  it("should throw an error when the string is in the wrong format", () => {
+    const param = "hello world!"
+    expect(() => UpcomingEventsFixedDateRangeSchema.parse(param)).toThrow()
   })
 })
 
 describe("CreateFixedDateRangeSchema tests", () => {
-  const staticNow = new Date("2024-01-01T00:00:00.000Z");
+  const staticNow = new Date("2024-01-01T00:00:00.000Z")
 
   beforeAll(() => {
-    jest.useFakeTimers().setSystemTime(staticNow);
-  });
+    jest.useFakeTimers().setSystemTime(staticNow)
+  })
 
   afterAll(() => {
-    jest.useRealTimers();
-  });
+    jest.useRealTimers()
+  })
 
   test("valid FixedDateRange instance with sufficient duration and future end date", () => {
     const testRange = dateRange(
       staticNow,
-      new Date(staticNow.getTime() + (MIN_EVENT_DURATION) * 1000)
-    );
+      new Date(staticNow.getTime() + MIN_EVENT_DURATION * 1000)
+    )
 
-    expect(CreateFixedDateRangeSchema.parse(testRange)).toEqual(testRange);
-  });
+    expect(CreateFixedDateRangeSchema.parse(testRange)).toEqual(testRange)
+  })
 
   test("invalid duration and end date in the past", () => {
     const start = new Date(staticNow.getTime() - 100000)
@@ -59,25 +92,25 @@ describe("CreateFixedDateRangeSchema tests", () => {
     const testRange = dateRange(
       start,
       new Date(start.getTime() + (MIN_EVENT_DURATION / 2) * 1000)
-    );
+    )
 
     try {
-      CreateFixedDateRangeSchema.parse(testRange);
+      CreateFixedDateRangeSchema.parse(testRange)
     } catch (e) {
       if (e instanceof ZodError) {
         expect(e.errors).toMatchObject([
           {
             code: "custom",
             message: "The duration must be at least 60 seconds.",
-            fatal: true,
+            fatal: true
           },
           {
             code: "custom",
             message: "The end date cannot be in the past.",
-            fatal: true,
-          },
-        ]);
+            fatal: true
+          }
+        ])
       }
     }
-  });
-});
+  })
+})

--- a/api/models/FixedDateRange.ts
+++ b/api/models/FixedDateRange.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { FixedDateRange } from "../../domain-models/FixedDateRange"
+import { base64URLDecode } from "../../lib/Base64URLCoding"
 
 /**
  * A zod schema to parse an {@link FixedDateRange} where the start and end dates
@@ -7,43 +8,56 @@ import { FixedDateRange } from "../../domain-models/FixedDateRange"
  */
 export const FixedDateRangeSchema = z.optionalParseable(
   FixedDateRange,
-  z.object({
+  z
+    .object({
       startDateTime: z.coerce.date(),
       endDateTime: z.coerce.date()
     })
-    .transform(({startDateTime, endDateTime}) => new FixedDateRange(startDateTime, endDateTime))
+    .transform(({ startDateTime, endDateTime }) => {
+      return new FixedDateRange(startDateTime, endDateTime)
+    })
 )
 
 export const MIN_EVENT_DURATION = 60
+
+export const UpcomingEventsFixedDateRangeSchema = z.optionalParseable(
+  FixedDateRange,
+  z.string().transform((str) => {
+    return FixedDateRangeSchema.parse(JSON.parse(base64URLDecode(str)))
+  })
+)
 
 /**
  * A Zod schema for creating a FixedDateRange with additional constraints for new Events:
  * - Duration must be at least MIN_EVENT_DURATION seconds.
  * - The end date cannot be in the past.
  */
-export const CreateFixedDateRangeSchema = FixedDateRangeSchema.superRefine((dateRange, ctx) => {
-  if (process.env.API_GENERATION_ENVIRONMENT) { // NB: dateRange is null when generating openapi schema
-    return;
+export const CreateFixedDateRangeSchema = FixedDateRangeSchema.superRefine(
+  (dateRange, ctx) => {
+    if (process.env.API_GENERATION_ENVIRONMENT) {
+      // NB: dateRange is null when generating openapi schema
+      return
+    }
+
+    const { startDateTime, endDateTime } = dateRange
+
+    const secondDiff = (endDateTime.getTime() - startDateTime.getTime()) / 1000
+    const isEndDatePast = endDateTime < new Date() // TODO: Compare with server's timezone
+
+    if (secondDiff < MIN_EVENT_DURATION) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "The duration must be at least 60 seconds.",
+        fatal: true
+      })
+    }
+
+    if (isEndDatePast) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "The end date cannot be in the past.",
+        fatal: true
+      })
+    }
   }
-
-  const { startDateTime, endDateTime } = dateRange;
-
-  const secondDiff = (endDateTime.getTime() - startDateTime.getTime()) / 1000;
-  const isEndDatePast = endDateTime < new Date(); // TODO: Compare with server's timezone
-
-  if (secondDiff < MIN_EVENT_DURATION) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "The duration must be at least 60 seconds.",
-      fatal: true
-    });
-  }
-
-  if (isEndDatePast) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "The end date cannot be in the past.",
-      fatal: true
-    });
-  }
-});
+)

--- a/lib/Base64URLCoding.test.ts
+++ b/lib/Base64URLCoding.test.ts
@@ -1,0 +1,11 @@
+import { base64URLDecode, base64URLEncode } from "./Base64URLCoding"
+
+describe("Base64URLCoding tests", () => {
+  test("encode", () => {
+    expect(base64URLEncode("hello, world")).toEqual("aGVsbG8sIHdvcmxk")
+  })
+
+  test("decode", () => {
+    expect(base64URLDecode("aGVsbG8sIHdvcmxk")).toEqual("hello, world")
+  })
+})

--- a/lib/Base64URLCoding.ts
+++ b/lib/Base64URLCoding.ts
@@ -10,3 +10,13 @@ export const base64URLDecode = (input: string) => {
   input += "=".repeat(padLength)
   return atob(input)
 }
+
+/**
+ * A Base64 URL String Encoder.
+ *
+ * @param input The string to encode.
+ * @returns The encoded string.
+ */
+export const base64URLEncode = (input: string) => {
+  return btoa(input).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}

--- a/lib/Base64URLCoding.ts
+++ b/lib/Base64URLCoding.ts
@@ -1,0 +1,12 @@
+/**
+ * A Base64 URL String Decoder.
+ *
+ * @param input The string to decode.
+ * @returns The decoded string.
+ */
+export const base64URLDecode = (input: string) => {
+  input = input.replace(/-/g, "+").replace(/_/g, "/")
+  const padLength = (4 - (input.length % 4)) % 4
+  input += "=".repeat(padLength)
+  return atob(input)
+}

--- a/specs.json
+++ b/specs.json
@@ -2379,6 +2379,14 @@
             "required": false,
             "name": "maxSecondsToStart",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "dateRange",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
This will allow the user's events to be queried by a date range. The query parameter accepts a base64 URL encoded fixed date range JSON payload. It's easier with query params to require the user to pass the entire json date range payload rather than pass 2 optionals for the start and end date respectively, or having to create an entirely new endpoint that mirrors 98% of the existing one. Ideally, we can transition the live events tracking on the frontend to use the new date range, but that's not needed so I've kept the `maxSecondsToStart` parameter for now.

## Tickets

https://trello.com/c/mcM6k8gP