### PR TITLE
Events Timeline Endpoint Schema

### DIFF
--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -363,6 +363,7 @@ export const TiFAPISchema = {
   timeline: endpointSchema({
     input: {
       query: z.object({
+        limit: z.coerce.number(),
         direction: EventsTimelineDirectionSchema,
         token: z.base64URLDecodedJSON(EventsTimelinePageTokenSchema).optional()
       })

--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -28,7 +28,8 @@ import {
   EventsInAreaResponseSchema,
   EventsResponseSchema,
   JoinEventResponseSchema,
-  EventsTimelinePageTokenSchema
+  EventsTimelinePageTokenSchema,
+  EventsTimelineDirectionSchema
 } from "./models/Event"
 import {
   RegisterPushTokenRequestSchema,
@@ -362,6 +363,7 @@ export const TiFAPISchema = {
   timeline: endpointSchema({
     input: {
       query: z.object({
+        direction: EventsTimelineDirectionSchema,
         token: z.base64URLDecodedJSON(EventsTimelinePageTokenSchema).optional()
       })
     },

--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -24,9 +24,11 @@ import { tifAPIErrorSchema } from "./models/Error"
 import {
   EventNotFoundErrorSchema,
   EventResponseSchema,
+  EventsTimelineResponseSchema,
   EventsInAreaResponseSchema,
   EventsResponseSchema,
-  JoinEventResponseSchema
+  JoinEventResponseSchema,
+  EventsTimelinePageTokenSchema
 } from "./models/Event"
 import {
   RegisterPushTokenRequestSchema,
@@ -351,6 +353,24 @@ export const TiFAPISchema = {
     httpRequest: {
       method: "GET",
       endpoint: `/event/upcomingEvents`
+    }
+  }),
+
+  /**
+   * Returns the user's events timeline.
+   */
+  timeline: endpointSchema({
+    input: {
+      query: z.object({
+        token: z.base64URLDecodedJSON(EventsTimelinePageTokenSchema).optional()
+      })
+    },
+    outputs: {
+      status200: EventsTimelineResponseSchema
+    },
+    httpRequest: {
+      method: "GET",
+      endpoint: `/event/timeline`
     }
   }),
 

--- a/api/models/Event.ts
+++ b/api/models/Event.ts
@@ -82,10 +82,12 @@ export const EventWhenBlockedByHostResponseSchema =
     tifAPIErrorSchema(BlockedYouStatusSchema.value)
   )
 
-export const EventsTimelinePageTokenSchema = z.object({
-  forwardStartDate: z.date(),
-  backwardStartDate: z.date()
-})
+export const EventsTimelinePageTokenSchema = z
+  .object({
+    forwardStartDate: z.date(),
+    backwardStartDate: z.date()
+  })
+  .partial()
 
 export const EventsTimelineDirectionSchema = z.enum(["forwards", "backwards"])
 

--- a/api/models/Event.ts
+++ b/api/models/Event.ts
@@ -81,3 +81,14 @@ export const EventWhenBlockedByHostResponseSchema =
   EventWhenBlockedByHostSchema.merge(
     tifAPIErrorSchema(BlockedYouStatusSchema.value)
   )
+
+export const EventsTimelinePageTokenSchema = z.object({
+  forwardStartDate: z.date(),
+  backwardStartDate: z.date()
+})
+
+export const EventsTimelineResponseSchema = EventsResponseSchema.extend({
+  nextToken: z.string(),
+  hasNextPage: z.boolean(),
+  hasPreviousPage: z.boolean()
+})

--- a/api/models/Event.ts
+++ b/api/models/Event.ts
@@ -87,6 +87,8 @@ export const EventsTimelinePageTokenSchema = z.object({
   backwardStartDate: z.date()
 })
 
+export const EventsTimelineDirectionSchema = z.enum(["forwards", "backwards"])
+
 export const EventsTimelineResponseSchema = EventsResponseSchema.extend({
   nextToken: z.string(),
   hasNextPage: z.boolean(),

--- a/api/models/FixedDateRange.ts
+++ b/api/models/FixedDateRange.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
 import { FixedDateRange } from "../../domain-models/FixedDateRange"
-import { base64URLDecode } from "../../lib/Base64URLCoding"
 
 /**
  * A zod schema to parse an {@link FixedDateRange} where the start and end dates
@@ -20,12 +19,8 @@ export const FixedDateRangeSchema = z.optionalParseable(
 
 export const MIN_EVENT_DURATION = 60
 
-export const UpcomingEventsFixedDateRangeSchema = z.optionalParseable(
-  FixedDateRange,
-  z.string().transform((str) => {
-    return FixedDateRangeSchema.parse(JSON.parse(base64URLDecode(str)))
-  })
-)
+export const UpcomingEventsFixedDateRangeSchema =
+  z.base64URLDecodedJSON(FixedDateRangeSchema)
 
 /**
  * A Zod schema for creating a FixedDateRange with additional constraints for new Events:

--- a/specs.json
+++ b/specs.json
@@ -2750,6 +2750,339 @@
         }
       }
     },
+    "/event/timeline": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "token",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Object with user data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 75
+                          },
+                          "description": {
+                            "type": "string",
+                            "maxLength": 500
+                          },
+                          "color": {
+                            "type": "string"
+                          },
+                          "attendeeCount": {
+                            "type": "number",
+                            "minimum": 0
+                          },
+                          "joinedDateTime": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "createdDateTime": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "updatedDateTime": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "hasArrived": {
+                            "type": "boolean"
+                          },
+                          "isChatExpired": {
+                            "type": "boolean"
+                          },
+                          "userAttendeeStatus": {
+                            "type": "string",
+                            "enum": [
+                              "not-participating",
+                              "hosting",
+                              "attending"
+                            ]
+                          },
+                          "settings": {
+                            "type": "object",
+                            "properties": {
+                              "shouldHideAfterStartDate": {
+                                "type": "boolean"
+                              },
+                              "isChatEnabled": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "shouldHideAfterStartDate",
+                              "isChatEnabled"
+                            ]
+                          },
+                          "time": {
+                            "type": "object",
+                            "properties": {
+                              "secondsToStart": {
+                                "type": "number"
+                              },
+                              "todayOrTomorrow": {
+                                "type": "string",
+                                "enum": [
+                                  "today",
+                                  "tomorrow"
+                                ]
+                              },
+                              "dateRange": {
+                                "type": "object",
+                                "properties": {
+                                  "startDateTime": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "endDateTime": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "startDateTime",
+                                  "endDateTime"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "secondsToStart",
+                              "dateRange"
+                            ]
+                          },
+                          "location": {
+                            "type": "object",
+                            "properties": {
+                              "coordinate": {
+                                "type": "object",
+                                "properties": {
+                                  "latitude": {
+                                    "type": "number",
+                                    "minimum": -90,
+                                    "maximum": 90
+                                  },
+                                  "longitude": {
+                                    "type": "number",
+                                    "minimum": -180,
+                                    "maximum": 180
+                                  }
+                                },
+                                "required": [
+                                  "latitude",
+                                  "longitude"
+                                ]
+                              },
+                              "arrivalRadiusMeters": {
+                                "type": "number"
+                              },
+                              "isInArrivalTrackingPeriod": {
+                                "type": "boolean"
+                              },
+                              "timezoneIdentifier": {
+                                "type": "string"
+                              },
+                              "placemark": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "country": {
+                                    "type": "string"
+                                  },
+                                  "postalCode": {
+                                    "type": "string"
+                                  },
+                                  "street": {
+                                    "type": "string"
+                                  },
+                                  "streetNumber": {
+                                    "type": "string"
+                                  },
+                                  "region": {
+                                    "type": "string"
+                                  },
+                                  "isoCountryCode": {
+                                    "type": "string"
+                                  },
+                                  "city": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "required": [
+                              "coordinate",
+                              "arrivalRadiusMeters",
+                              "isInArrivalTrackingPeriod",
+                              "timezoneIdentifier"
+                            ]
+                          },
+                          "previewAttendees": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "role": {
+                                  "type": "string",
+                                  "enum": [
+                                    "hosting",
+                                    "attending"
+                                  ]
+                                },
+                                "hasArrived": {
+                                  "type": "boolean"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "handle": {
+                                  "type": "string",
+                                  "pattern": "^[A-Za-z0-9_]{1,15}"
+                                },
+                                "profileImageURL": {
+                                  "type": "string",
+                                  "format": "uri"
+                                },
+                                "relationStatus": {
+                                  "type": "string",
+                                  "enum": [
+                                    "blocked-them",
+                                    "not-friends",
+                                    "friend-request-sent",
+                                    "friend-request-received",
+                                    "friends",
+                                    "current-user"
+                                  ]
+                                },
+                                "joinedDateTime": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "arrivedDateTime": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "role",
+                                "hasArrived",
+                                "name",
+                                "handle",
+                                "relationStatus",
+                                "joinedDateTime"
+                              ]
+                            }
+                          },
+                          "host": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "handle": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z0-9_]{1,15}"
+                              },
+                              "profileImageURL": {
+                                "type": "string",
+                                "format": "uri"
+                              },
+                              "relationStatus": {
+                                "type": "string",
+                                "enum": [
+                                  "blocked-them",
+                                  "not-friends",
+                                  "friend-request-sent",
+                                  "friend-request-received",
+                                  "friends",
+                                  "current-user"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "handle",
+                              "relationStatus"
+                            ]
+                          },
+                          "endedDateTime": {
+                            "type": "string",
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "title",
+                          "attendeeCount",
+                          "createdDateTime",
+                          "updatedDateTime",
+                          "hasArrived",
+                          "isChatExpired",
+                          "userAttendeeStatus",
+                          "settings",
+                          "time",
+                          "location",
+                          "previewAttendees",
+                          "host"
+                        ]
+                      }
+                    },
+                    "nextToken": {
+                      "type": "string"
+                    },
+                    "hasNextPage": {
+                      "type": "boolean"
+                    },
+                    "hasPreviousPage": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "events",
+                    "nextToken",
+                    "hasNextPage",
+                    "hasPreviousPage"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/user/notifications/push/register": {
       "post": {
         "requestBody": {

--- a/specs.json
+++ b/specs.json
@@ -2755,6 +2755,18 @@
         "parameters": [
           {
             "schema": {
+              "type": "string",
+              "enum": [
+                "forwards",
+                "backwards"
+              ]
+            },
+            "required": true,
+            "name": "direction",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "required": false,

--- a/specs.json
+++ b/specs.json
@@ -2755,6 +2755,15 @@
         "parameters": [
           {
             "schema": {
+              "type": "number",
+              "nullable": true
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
               "type": "string",
               "enum": [
                 "forwards",


### PR DESCRIPTION
Introduces the schema for a new endpoint that will power the user's events timeline present in our upcoming prototypes. The endpoint utilizes a page token that contains the offsets for moving backwards and forwards in the timeline. The user will pass a query parameter indicating which direction in time they want to move in, and the API will request events in that direction. The response contains the updated token which will be passed in with the next request, and 2 boolean fields indicating whether or not the user can move backwards or forwards in time from then on.

The token is not passed in with the first request. In such a case, the API will look for events using the direction, limit, starting at the current date.

The token is passed as a base 64 URL encoded JSON payload as a query parameter. I've also made a zod utility to make parsing these kinds of payloads easier.

## Tickets

https://trello.com/c/mcM6k8gP