### PR TITLE
Updated Timeline Endpoint

### DIFF
--- a/api/TiFAPISchema.ts
+++ b/api/TiFAPISchema.ts
@@ -359,6 +359,24 @@ export const TiFAPISchema = {
 
   /**
    * Returns the user's events timeline.
+   *
+   * You pass the direction and the number of events you want to fetch from the timeline as query
+   * parameters. When fetching in the backwards direction, ongoing events are included, but no
+   * ongoing events are included when fetching forwards.
+   *
+   * The first request will divide the `limit` parameter, and fetch half the limit in the forwards
+   * direction, and half the limit in the backwards direction.
+   *
+   * After the first request, the endpoint will respond with a `nextToken` field. Include this
+   * token as a query parameter on all subsequent requests to this endpoint in order to get the
+   * most up to date events (regardless of direction).
+   *
+   * To check if there are no more pages to fetch in a specific direction, each response includes
+   * a `hasNextForwardPage` and `hasNextBackwardPage` fields that indicates whether or not you can
+   * fetch another page in the direction you passed to the request.
+   *
+   * The client is responsible for handling duplicate events returned on different pages. This is
+   * to ensure that we display up to date data as much as possible in the UI.
    */
   timeline: endpointSchema({
     input: {

--- a/api/models/Event.ts
+++ b/api/models/Event.ts
@@ -84,15 +84,28 @@ export const EventWhenBlockedByHostResponseSchema =
 
 export const EventsTimelinePageTokenSchema = z
   .object({
-    forwardStartDate: z.date(),
-    backwardStartDate: z.date()
+    startDate: z.coerce.date(),
+    forwardOffset: z.coerce.number().optional(),
+    backwardOffset: z.coerce.number().optional()
   })
   .partial()
 
+export type EventsTimelinePageToken = z.infer<
+  typeof EventsTimelinePageTokenSchema
+>
+
 export const EventsTimelineDirectionSchema = z.enum(["forwards", "backwards"])
+
+export type EventsTimelineDirection = z.infer<
+  typeof EventsTimelineDirectionSchema
+>
 
 export const EventsTimelineResponseSchema = EventsResponseSchema.extend({
   nextToken: z.string(),
-  hasNextPage: z.boolean(),
-  hasPreviousPage: z.boolean()
+  hasNextForwardPage: z.boolean(),
+  hasNextBackwardPage: z.boolean()
 })
+
+export type EventsTimelineResponse = z.infer<
+  typeof EventsTimelineResponseSchema
+>

--- a/specs.json
+++ b/specs.json
@@ -3084,18 +3084,18 @@
                     "nextToken": {
                       "type": "string"
                     },
-                    "hasNextPage": {
+                    "hasNextForwardPage": {
                       "type": "boolean"
                     },
-                    "hasPreviousPage": {
+                    "hasNextBackwardPage": {
                       "type": "boolean"
                     }
                   },
                   "required": [
                     "events",
                     "nextToken",
-                    "hasNextPage",
-                    "hasPreviousPage"
+                    "hasNextForwardPage",
+                    "hasNextBackwardPage"
                   ]
                 }
               }


### PR DESCRIPTION
Needed to make some updates to the timeline endpoint, and also added doc comment to explain its usage.

```
Returns the user's events timeline.

You pass the direction and the number of events you want to fetch from the timeline as query parameters. When fetching in the backwards direction, ongoing events are included, but no ongoing events are included when fetching forwards.

The first request will divide the `limit` parameter, and fetch half the limit in the forwards direction, and half the limit in the backwards direction.

After the first request, the endpoint will respond with a `nextToken` field. Include this token as a query parameter on all subsequent requests to this endpoint in order to get the most up to date events (regardless of direction).

To check if there are no more pages to fetch in a specific direction, each response includes a `hasNextForwardPage` and `hasNextBackwardPage` fields that indicates whether or not you can fetch another page in the direction you passed to the request.

The client is responsible for handling duplicate events returned on different pages. This is to ensure that we display up to date data as much as possible in the UI.
```

## Tickets

https://trello.com/c/mcM6k8gP